### PR TITLE
Add Sci-Hub domains to the global list.

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1205,3 +1205,8 @@ https://www.transferbigfiles.com,MMED,Multimedia sharing,2014-04-15,citizenlab,
 https://www.tumblr.com,FEXP,Free expression and media freedom,2014-04-15,citizenlab,
 https://www.yola.com,HOST,Web hosting sites and portals,2014-04-15,citizenlab,
 https://www.exploit-db.com/,HACK,Hacking Tools,2016-06-10,OONI,
+http://sci-hub.org/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,taken down by court order November 2015 https://torrentfreak.com/court-orders-shutdown-of-libgen-bookfi-and-sci-hub-151102/
+http://sci-hub.io/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,appeared to replace sci-hub.io November 2015 https://torrentfreak.com/sci-hub-and-libgen-resurface-after-being-shut-down-151121/ taken down by court order May 2016 https://torrentfreak.com/elsevier-complaint-shuts-down-sci-hub-domain-name-160504/
+http://sci-hub.ac/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,
+http://sci-hub.bz/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,
+http://sci-hub.cc/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,


### PR DESCRIPTION
taken down in November 2015:
sci-hub.org

taken down in May 2016:
sci-hub.io

still active according to https://en.wikipedia.org/wiki/Sci-Hub:
sci-hub.ac
sci-hub.bz
sci-hub.cc

Not added to the list, but other current access methods are
http://31.184.194.81/ and http://scihub22266oqcxt.onion/.

The IP address has HTTPS; the certificate's CN is sci-hub.ac.