### PR TITLE
Fix the note for http://sci-hub.io/.

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1206,7 +1206,7 @@ https://www.tumblr.com,FEXP,Free expression and media freedom,2014-04-15,citizen
 https://www.yola.com,HOST,Web hosting sites and portals,2014-04-15,citizenlab,
 https://www.exploit-db.com/,HACK,Hacking Tools,2016-06-10,OONI,
 http://sci-hub.org/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,taken down by court order November 2015 https://torrentfreak.com/court-orders-shutdown-of-libgen-bookfi-and-sci-hub-151102/
-http://sci-hub.io/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,appeared to replace sci-hub.io November 2015 https://torrentfreak.com/sci-hub-and-libgen-resurface-after-being-shut-down-151121/ taken down by court order May 2016 https://torrentfreak.com/elsevier-complaint-shuts-down-sci-hub-domain-name-160504/
+http://sci-hub.io/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,appeared to replace sci-hub.org November 2015 https://torrentfreak.com/sci-hub-and-libgen-resurface-after-being-shut-down-151121/ taken down by court order May 2016 https://torrentfreak.com/elsevier-complaint-shuts-down-sci-hub-domain-name-160504/
 http://sci-hub.ac/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,
 http://sci-hub.bz/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,
 http://sci-hub.cc/,P2P,Peer-to-peer file sharing,2016-07-13,David Fifield,


### PR DESCRIPTION
sci-hub.io replaced sci-hub.org.

This is a fix to pull request #63.