### PR TITLE
Added Khabaristan Times site to Pakistani test list

### DIFF
--- a/lists/pk.csv
+++ b/lists/pk.csv
@@ -945,3 +945,4 @@ http://islamandhomosexuality.com/5-ways-pakistan-gay-friendly/,LGBT,LGBT,2016-07
 http://www.humanrightsfirst.org/blog/lgbt-voices-equality-pakistan/,LGBT,LGBT,2016-07-20,OONI,
 http://www.towleroad.com/2016/06/lgbt-pakistan/,LGBT,LGBT,2016-07-20,OONI,
 http://www.pakistaniwomen.org/,HUMR,Human Rights Issues,2016-07-20,OONI,
+https://khabaristantimes.com/,POLR,Political Criticism,2017-02-08,OONI,


### PR DESCRIPTION
Satire website Khabaristan Times has reportedly been blocked in Pakistan since 25th January 2017 (http://www.dawn.com/news/1311841). I've added this site (https://khabaristantimes.com/) to the Pakistani test list. 