### PR TITLE
added proper Signal server URLs to .eg list

### DIFF
--- a/lists/eg.csv
+++ b/lists/eg.csv
@@ -56,8 +56,10 @@ http://rassd.com,NEWS,News Media,2014-04-15,citizenlab,
 http://samy.attahawy.net,NEWS,News Media,2014-04-15,citizenlab,
 http://seekingfreedom.blogspot.com,NEWS,News Media,2014-04-15,citizenlab,
 http://tadwen.com,NEWS,News Media,2014-04-15,citizenlab,
-http://textsecure-service-ca.whispersystems.org,COMT,Communication Tools,2017-01-19,citizenlab,Used by Signal desktop
-https://textsecure-service-ca.whispersystems.org,COMT,Communication Tools,2017-01-19,citizenlab,Used by Signal desktop with cert signed only by whispersystems
+https://textsecure-service-ca.whispersystems.org:80,COMT,Communication Tools,2017-02-10,citizenlab,Used by Signal Desktop for communication
+https://textsecure-service-ca.whispersystems.org:4433,COMT,Communication Tools,2017-02-10,citizenlab,Used by Signal Desktop for communication
+https://textsecure-service-ca.whispersystems.org:8443,COMT,Communication Tools,2017-02-10,citizenlab,Used by Signal Desktop for communication
+https://whispersystems-textsecure-attachments.s3.amazonaws.com,COMT,Communication Tools,2017-02-10,citizenlab,Used by Signal desktop for attachments
 http://theegyptblog.blogspot.com,NEWS,News Media,2014-04-15,citizenlab,
 http://tortureinegypt.net,POLR,Political Criticism,2014-04-15,citizenlab,
 https://twitter.com/ikhwanweb,NEWS,News Media,2014-04-15,citizenlab,


### PR DESCRIPTION
Added the correct URLs for Signal Desktop testing please review to make sure specifying the port doesn't break anything you have before merge.  Signal desktop does TLS over port 80, 4433, and 8443 so we test all these as well as the server used to send attachments.

Also this might make more sense to move to the global list in the future but I think we should clean up that list before adding to it.