### PR TITLE
add ch.csv with c9c.net

### DIFF
--- a/lists/ch.csv
+++ b/lists/ch.csv
@@ -1,0 +1,2 @@
+url,category_code,category_description,date_added,source,notes
+http://c9c.net,ANON,Anonymization and circumvention tools,2017-03-05,Markus Ritzmann,


### PR DESCRIPTION
c9c.net is DNS blocked by Swisscom.ch a larger ISP in Switzerland

```
markus@zoidberg:~$ nslookup c9c.net 195.186.1.111
Server:		195.186.1.111
Address:	195.186.1.111#53
 
Non-authoritative answer:
Name:	c9c.net
Address: 195.186.135.218
 
markus@zoidberg:~$ nslookup c9c.net 8.8.8.8
Server:		8.8.8.8
Address:	8.8.8.8#53
 
Non-authoritative answer:
Name:	c9c.net
Address: 63.247.87.242
```

reason: `Access to this site is blocked due to a court order.`