### PR TITLE
torproject.org

### DIFF
--- a/lists/eg.csv
+++ b/lists/eg.csv
@@ -65,6 +65,7 @@ https://textsecure-service-ca.whispersystems.org:4433,COMT,Communication Tools,2
 https://textsecure-service-ca.whispersystems.org:8443,COMT,Communication Tools,2017-02-10,citizenlab,Used by Signal Desktop for communication
 https://whispersystems-textsecure-attachments.s3.amazonaws.com,COMT,Communication Tools,2017-02-10,citizenlab,Used by Signal desktop for attachments
 http://theegyptblog.blogspot.com,NEWS,News Media,2014-04-15,citizenlab,
+https://torproject.org,ANON,Anonymization and circumvention tools,2017-05-27,ADEF,blocked as of date added
 http://tortureinegypt.net,POLR,Political Criticism,2014-04-15,citizenlab,
 https://twitter.com/ikhwanweb,NEWS,News Media,2014-04-15,citizenlab,
 https://twitter.com/muhammadmorsi,NEWS,News Media,2014-04-15,citizenlab,


### PR DESCRIPTION
Torproject.org is reported by some people to be blocked - with its subdomains "bridges" - following blocking of 21 news sites, and possible hike in usage of Tor by Internet users in Egypt, and an increase in the recommendations to use Tor by people to others on socialmedia sites.