### PR TITLE
Add URLs related to the FreeU web browser to the UA list.

### DIFF
--- a/lists/ua.csv
+++ b/lists/ua.csv
@@ -144,6 +144,8 @@ http://free.newyork.ru,COMT,Communication Tools,2014-04-15,citizenlab,
 http://freedomhouse.org/russia-eve-sochi,HUMR,Human Rights Issues,2014-04-15,citizenlab,
 http://freepromote.ru,MMED,Media sharing,2014-04-15,citizenlab,
 http://freepussyriot.org,NEWS,News Media,2014-04-15,citizenlab,
+https://freeu.online/,ANON,Anonymization and circumvention tools,2017-05-31,David Fifield,Download site for the FreeU web browser
+https://freeu.zone/,ANON,Anonymization and circumvention tools,2017-05-31,David Fifield,Download site for the FreeU web browser
 http://freeware32.ru,MMED,Media sharing,2014-04-15,citizenlab,
 http://from-ua.com,NEWS,News Media,2014-04-15,citizenlab,
 http://frontzmin.ua,NEWS,News Media,2014-04-15,citizenlab,
@@ -301,6 +303,7 @@ http://o-leusenko-politolog.blogspot.com,NEWS,News Media,2014-04-15,citizenlab,
 http://obkom.net.ua,NEWS,News Media,2014-04-15,citizenlab,
 http://oblicomorale.blogspot.com,NEWS,News Media,2014-04-15,citizenlab,
 http://obozrevatel.com,NEWS,News Media,2014-04-15,citizenlab,
+https://ok.ru/google55e918a7d2970a76.html,ANON,Anonymization and circumvention tools,2017-05-31,David Fifield,Canary URL used by the FreeU web browser to test blocking of VKontakte (https://bugs.torproject.org/22369#comment:5)
 http://okpz.freeservers.com,HUMR,Human Rights Issues,2014-04-15,citizenlab,
 http://omen.ru,DATE,Online Dating,2014-04-15,citizenlab,
 http://onlinefilms.com.ua,MISC,Miscelaneous content,2014-04-15,citizenlab,
@@ -433,6 +436,12 @@ http://ukrnews24.com,NEWS,News Media,2014-04-15,citizenlab,
 http://uncyclopedia.wikia.com/wiki/main_page,NEWS,News Media,2014-04-15,citizenlab,
 http://ungheni.ru,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,
 http://unian.net,NEWS,News Media,2014-04-15,citizenlab,
+https://update.brwsrapi.com/blckd.json,ANON,Anonymization and circumvention tools,2017-05-31,David Fifield,FreeU web browser list of potentially blocked domains (https://bugs.torproject.org/22369#comment:3)
+https://update.mrbrwsr.com/blckd.json,ANON,Anonymization and circumvention tools,2017-05-31,David Fifield,FreeU web browser list of potentially blocked domains (https://bugs.torproject.org/22369#comment:3)
+https://update.savebrwsr.com/blckd.json,ANON,Anonymization and circumvention tools,2017-05-31,David Fifield,FreeU web browser list of potentially blocked domains (https://bugs.torproject.org/22369#comment:3)
+https://update.svbrwsr.com/blckd.json,ANON,Anonymization and circumvention tools,2017-05-31,David Fifield,FreeU web browser list of potentially blocked domains (https://bugs.torproject.org/22369#comment:3)
+https://update.updtapi.com/blckd.json,ANON,Anonymization and circumvention tools,2017-05-31,David Fifield,FreeU web browser list of potentially blocked domains (https://bugs.torproject.org/22369#comment:3)
+https://update.updtbrwsr.com/blckd.json,ANON,Anonymization and circumvention tools,2017-05-31,David Fifield,FreeU web browser list of potentially blocked domains (https://bugs.torproject.org/22369#comment:3)
 http://urbantimes.co,NEWS,News Media,2014-04-15,citizenlab,
 http://vdagestan.com,MILX,Terrorism and Militants,2014-04-15,citizenlab,
 http://vdagestan.info,MILX,Terrorism and Militants,2014-04-15,citizenlab,
@@ -444,6 +453,7 @@ http://video.meta.ua,NEWS,News Media,2014-04-15,citizenlab,
 http://vk.com,HUMR,Human Rights Issues,2014-04-15,citizenlab,
 http://vk.com/live_ukr,NEWS,News Media,2014-04-15,citizenlab,
 http://vk.com/minitrue,NEWS,News Media,2014-04-15,citizenlab,
+https://vk.com/ping.txt,ANON,Anonymization and circumvention tools,2017-05-31,David Fifield,Canary URL used by the FreeU web browser to test blocking of VKontakte (https://bugs.torproject.org/22369#comment:5)
 http://vk.com/public62043361,POLR,Political Criticism,2014-04-15,citizenlab,
 http://vkontakte.ru,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,
 http://vresearche.com,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,


### PR DESCRIPTION
Download sites/home pages:
	https://freeu.online/
	https://freeu.zone/
(http versions currently 307 redirect to https)

Potential blocklist servers:
	https://update.brwsrapi.com/blckd.json
	https://update.mrbrwsr.com/blckd.json
	https://update.savebrwsr.com/blckd.json
	https://update.svbrwsr.com/blckd.json
	https://update.updtapi.com/blckd.json
	https://update.updtbrwsr.com/blckd.json
(The same domains also serve the actual downloads, e.g. freeu.exe. Also
versions without the "update." seem to work, but are not added to the
list.)

Canary URLs (we suspect that FreeU fetches these URLs as a check to see
if blocking is happening):
	https://vk.com/ping.txt
	https://ok.ru/google55e918a7d2970a76.html
Before 2017-05-25, these used http, not https.

More details here: https://bugs.torproject.org/22369