### PR TITLE
added bbg urls

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -12,6 +12,8 @@ http://adium.im,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2
 http://adultfriendfinder.com,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://advocacy.globalvoicesonline.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://alt.com,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://amharic.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://amharic.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://amphetamines.com,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://amygoodloe.com/lesbian-dot-org/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://anon.inf.tu-dresden.de,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -23,9 +25,10 @@ http://archive.org,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Upd
 https://archive.org/web/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://astalavista.box.sk,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://attrition.org/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://avaaz.org,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://autistici.org,HOST,Hosting and Blogging Platforms,2017-08-08,samba,created by smb
-https://noblogs.org,HOST,Hosting and Blogging Platforms,2017-08-08,samba,created by smb
+http://avaaz.org,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://ba.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://ba.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 https://bebo.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://beeg.com,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://beyondexgay.com/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -35,6 +38,8 @@ http://bittornado.com,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on
 http://blackberry.com,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://blog.com,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://blogmarks.net,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://blogs.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://blogs.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://blogspot.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://blueskyswimwear.com,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://bnaibrith.org,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -44,6 +49,8 @@ http://bravotube.net,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2
 https://bridges.torproject.org,ANON,Anonymization and circumvention tools,2017-05-31,ADEF,blocked in Egypt as of 2017-05-27
 http://btggaming.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://btguard.com,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://burmese.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://burmese.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://cannabis.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://care.org,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://carnegieendowment.org/,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -67,6 +74,8 @@ http://creativecommons.org,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI
 https://cryptome.org,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://cultdeadcow.com,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://cyber.harvard.edu/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://da.azadiradio.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://da.azadiradio.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://dcemail.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://ddo.com/,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://de.lirio.us,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -85,9 +94,13 @@ https://duckduckgo.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OON
 http://earth-liberation-front.org,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://ebuddy.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://ecstasy.org,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://editorials.voa.gov,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://editorials.voa.gov,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://emailaddresses.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://emchurch.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://en-ville.orange.fr/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://en.radiofarda.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://en.radiofarda.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 https://en.wikipedia.org/wiki/the_holocaust,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://encrypted.google.com,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://epic.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -106,6 +119,8 @@ http://freemuse.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by O
 https://freenetproject.org/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://friends.walla.co.il/#/login,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://fsrn.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://gandhara.rferl.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://gandhara.rferl.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://gawker.com,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://gaytoday.com,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://global.blackberry.com/en/home.html,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -115,6 +130,8 @@ http://go.com,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-
 https://goaskalice.columbia.edu/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://godhatesfags.com,HATE,Hate Speech,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://gpgtools.org,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://gr.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://gr.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 https://groups.google.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://groups.yahoo.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://guardianproject.info,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -132,6 +149,7 @@ https://iarf.net/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-
 https://identi.ca/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://ikhwanonline.com/,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://ilga.org/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+https://imageshack.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://imesh.com/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://imgur.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://imp.free.fr/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -140,6 +158,8 @@ https://infidels.org/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 201
 http://insecure.org/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://international.ohmynews.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://ipi.media/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://ir.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://ir.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://isaalmasih.net,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://islamonline.net/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://iwhc.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -149,16 +169,26 @@ https://jezebel.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017
 http://justicewomen.com/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://kabobfest.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://khilafah.net,MILX,Terrorism and Militants,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://khmer.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://khmer.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://kickassclassical.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://kids.yahoo.com,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://kidshealth.org/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://krishna.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://ktat.krymr.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://ktat.krymr.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://laborrights.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://lao.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://lao.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://lauraannjacobs.com,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://learningenglish.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://learningenglish.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://lgbt.foundation/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://lifestream.aol.com,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://login.infomaniak.com/loginWebmail,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://login.live.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://m.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://m.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 https://mail.ru/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://mail.yahoo.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://mail.yandex.ru,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -168,6 +198,8 @@ https://medpot.net/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI o
 https://metasploit.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://minorityrights.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://mixi.jp/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://mk.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://mk.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://moqavemat.ir,MILX,Terrorism and Militants,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://movabletype.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://mp3.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -177,6 +209,7 @@ https://myspace.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI
 http://ncac.org/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://news.google.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://nmap.org/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+https://noblogs.org,HOST,Hosting and Blogging Platforms,2017-08-08,samba,created by smb
 http://norml.org/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://now.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://nypost.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -191,6 +224,8 @@ https://openvpn.net,ANON,Anonymization and circumvention tools,2014-04-15,citize
 http://opportunity.org/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://otr.cypherpunks.ca/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://outlook.live.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://pa.azadiradio.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://pa.azadiradio.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 https://packetstormsecurity.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://panties.com/,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://peacefire.org/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -203,7 +238,13 @@ https://plan-uk.org/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 201
 https://plus.google.com,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://plus.im,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://postimage.io/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://pressroom.rferl.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://pressroom.rferl.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://progressio.org.uk/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://projects.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://projects.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://pronounce.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://pronounce.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://protectionline.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://proxify.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://proxy.org/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -218,6 +259,20 @@ http://reliefweb.int/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2
 http://risebroadband.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://riseup.net,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://rsf.org/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://ru.krymr.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://ru.krymr.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://rus.azathabar.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://rus.azathabar.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://rus.azattyk.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://rus.azattyk.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://rus.azattyq.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://rus.azattyq.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://rus.azatutyun.am,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://rus.azatutyun.am,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://rus.ozodi.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://rus.ozodi.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://rus.ozodlik.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://rus.ozodlik.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://russia.tv,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://sakhr.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://sci-hub.ac/,FILE,File-sharing,2016-07-13,David Fifield,Updated by OONI on 2017-02-14
@@ -252,9 +307,12 @@ http://technorati.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab
 http://teenadvice.about.com,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://telecomix.org,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://thehackernews.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+https://thehiddenwiki.org,MISC,Miscelaneous content,2017-08-15,A.Gh.,blocked in Egypt and probably elsewhere
 http://thenationalcampaign.org/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://thepiratebay.org,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://thepiratebay.se,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://tigrigna.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://tigrigna.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://timesofindia.indiatimes.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://tinyurl.com,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://tor.eff.org/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -276,6 +334,10 @@ http://twitter.com,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI o
 https://twitter.com,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://twitter.com/anonops,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://twitter.com/youranonnews/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://ua.krymr.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://ua.krymr.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://ukrainian.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://ukrainian.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://ultrasurf.us,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://ultrasurf.us,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://unpo.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -284,6 +346,10 @@ https://veracrypt.codeplex.com/,ANON,Anonymization and circumvention tools,2014-
 http://vho.org,HATE,Hate Speech,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://video.google.com,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://vimeo.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://voa.pangea-cms.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://voa.pangea-cms.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://voice.yahoo.jajah.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://warc.jalb.de,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://web.unep.org/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -350,6 +416,16 @@ http://www.altavista.com,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OO
 http://www.altpenis.com,PUBH,Public Health,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.amazon.com/,COMM,E-commerce,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.americannaziparty.com,HATE,Hate Speech,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.amerikaninsesi.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.amerikaninsesi.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.amerikaninsesi.org,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.amerikaninsesi.org,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.amerikaovozi.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.amerikaovozi.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.amerikayidzayn.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.amerikayidzayn.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.amerikiskhma.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.amerikiskhma.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 https://www.amnesty.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.ananzi.co.za,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.angelfire.lycos.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -380,6 +456,18 @@ http://www.atimes.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2
 http://www.auduboninternational.org,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.avert.org,PUBH,Public Health,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.awid.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.azadliq.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.azadliq.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.azathabar.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.azathabar.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.azatliq.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.azatliq.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.azattyk.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.azattyk.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.azattyq.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.azattyq.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.azatutyun.am,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.azatutyun.am,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.babylon-x.com,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.bacardi.com,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.backtrack-linux.org,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -388,6 +476,8 @@ https://www.baidu.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI
 http://www.barmeister.com,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.barnesandnoble.com/,COMM,E-commerce,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.bat.com,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.bbc.co.uk,NEWS,News Media,2017-07-19,OONI,
+http://www.bbc.com,NEWS,News Media,2017-07-19,OONI,
 http://www.bbc.com/news,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.bearshare.com,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.beer.com,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -465,10 +555,14 @@ http://www.crs.org,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-
 http://www.cseindia.org,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.csidonline.org/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.csmonitor.com,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.currenttime.tv,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.currenttime.tv,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.cwgl.rutgers.edu,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.cyber-pirates.org,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.dailymail.co.uk,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.dailymotion.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.darivoa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.darivoa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://www.darknet.org.uk,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.darpa.mil,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.date.com,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -482,6 +576,10 @@ https://www.defense.gov/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI o
 http://www.delicates.co.uk,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.democracycaucus.net,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.democracynow.org/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.dengeamerika.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.dengeamerika.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.dengiamerika.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.dengiamerika.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://www.depositfiles.com,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.derechos.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.dfid.gov.uk,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -517,6 +615,8 @@ https://www.eff.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by O
 http://www.efindlove.com,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.efonica.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.eharmony.com,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.ekhokavkaza.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.ekhokavkaza.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.eln-voces.com,MILX,Terrorism and Militants,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.eluniversal.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.emule.com/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -528,14 +628,20 @@ http://www.episcopalrelief.org/,REL,Religion,2014-04-15,citizenlab,Updated by OO
 https://www.erowid.org/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.eurogrand.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.europacasino.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.europalibera.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.europalibera.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.euthanasia.cc,PUBH,Public Health,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.eveonline.com/,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.evropaelire.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.evropaelire.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.excite.com,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.exgay.com,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.exmormon.org,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.exploit-db.com/,HACK,Hacking Tools,2016-06-10,OONI,Updated by OONI on 2017-02-14
 http://www.facebook.com,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.facebook.com,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.factograph.info,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.factograph.info,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.familiesaretalking.org,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.familycareintl.org,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.fark.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -590,6 +696,8 @@ http://www.ghostrecon.com,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2
 http://www.giganews.com,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.ginvodka.org,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.glaad.org,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.glasamerike.net,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.glasamerike.net,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://www.glbtqarchive.com/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.glil.org,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.globalfire.tv,HATE,Hate Speech,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -605,6 +713,8 @@ http://www.goarch.org,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017
 https://www.godaddy.com,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.godalone.org/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.goldenrivieracasino.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.golos-ameriki.ru,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.golos-ameriki.ru,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://www.google.com,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.google.com,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.google.com/search?q=gay,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -631,7 +741,6 @@ http://www.harkatulmujahideen.org,MILX,Terrorism and Militants,2014-04-15,citize
 https://www.helvetas.ch/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.herdict.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.heritage.org,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-https://thehiddenwiki.org,MISC,Miscelaneous content,2017-08-15,A.Gh.,blocked in Egypt and probably elsewhere
 https://www.hidemyass.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.hightail.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.hitler.org,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -665,6 +774,8 @@ http://www.icrw.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OO
 https://www.ict.org.il/,MILX,Terrorism and Militants,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.ictj.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.idea.int,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.idelreal.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.idelreal.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 https://www.idrc.ca/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.idsoftware.com,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.iea.org,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -690,6 +801,8 @@ http://www.indiatimes.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI 
 http://www.inetprivacy.com,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.infowar-monitor.net,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.inminds.co.uk,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.insidevoa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.insidevoa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 https://www.instagram.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.interactworldwide.org,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.internationalrivers.org/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -724,6 +837,8 @@ http://www.jmarshall.com/tools/cgiproxy/,ANON,Anonymization and circumvention to
 http://www.jsf.mil,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.judaism.com,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.judaismconversion.org,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.kavkazr.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.kavkazr.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.kazaa.com,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.kbs-frb.be/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.kcna.kp,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -747,8 +862,8 @@ http://www.lesbiansubmission.com,PORN,Pornography,2014-04-15,citizenlab,Updated 
 http://www.lingerieatlarge.com,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.lingeriebowl.com,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.lingo.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-https://www.linkedin.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.linkedin.com/,GRP,Social Networking,2016-11-11,citizenlab,Updated by OONI on 2017-02-14
+https://www.linkedin.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.linphone.org,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.livejournal.com,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.liveleak.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -769,6 +884,8 @@ https://www.mariestopes.org.uk/,PUBH,Public Health,2014-04-15,citizenlab,Updated
 http://www.marijuana.com,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.martus.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.marxists.org/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.mashaalradio.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.mashaalradio.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.match.com,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.mate1.com,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.matrimony.org,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -834,6 +951,7 @@ http://www.oovoo.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI o
 http://www.opec.org,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.opendns.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.opensocietyfoundations.org/,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+https://www.opentech.fund/,HUMR,Human Rights Issues,2017-09-26,OONI,
 https://www.opioids.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.originalelf.com,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.orthodoxconvert.info,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -841,12 +959,18 @@ http://www.osce.org,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 201
 https://www.ou.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.outrightinternational.org/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.oxfam.org/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.ozodi.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.ozodi.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.ozodlik.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.ozodlik.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.pacom.mil,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.paganpride.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.paltalk.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.pandora.com,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.partypoker.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.partypoker.net/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.pashtovoa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.pashtovoa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 https://www.paypal.com,COMM,E-commerce,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.pc2call.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.pcgamer.com,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -871,6 +995,8 @@ http://www.poker.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-
 http://www.pokerpages.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.pokerroom.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.pokerstars.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.polygraph.info,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.polygraph.info,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.pornhub.com/,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2017-08-05
 http://www.positive.org,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.postcards-for-iran.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -889,7 +1015,19 @@ http://www.queernet.org,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-
 https://www.queerty.com/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.rackspace.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.radicalparty.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.radioazadlyg.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.radioazadlyg.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.radiofarda.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.radiofarda.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.radioislam.org,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.radiomarsho.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.radiomarsho.com,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.radiosvoboda.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.radiosvoboda.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.radiotavisupleba.ge,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.radiotavisupleba.ge,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.radiyoyacuvoa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.radiyoyacuvoa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 https://www.rambler.ru/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.ran.org,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.rbf.org,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -903,7 +1041,33 @@ https://www.reproductiverights.org/,HUMR,Human Rights Issues,2014-04-15,citizenl
 http://www.repubblica.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.rescue.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.rfa.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.rfa.org,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rfa.org/burmese,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org/burmese,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rfa.org/cantonese,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org/cantonese,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rfa.org/english,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org/english,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rfa.org/khmer,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org/khmer,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rfa.org/korean,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org/korean,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rfa.org/lao,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org/lao,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rfa.org/mandarin,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org/mandarin,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rfa.org/tibetan,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org/tibetan,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rfa.org/uyghur,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org/uyghur,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rfa.org/vietnamese,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+https://www.rfa.org/vietnamese,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
+http://www.rferl.mobi,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.rferl.mobi,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.rferl.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.rferl.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.rferl.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.rfi.fr,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.riftgame.com,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.righttodie.ca,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -949,6 +1113,10 @@ http://www.siecus.org,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on
 http://www.sina.com.cn,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.skype.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.slideshare.net,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.slobodnaevropa.mk,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.slobodnaevropa.mk,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.slobodnaevropa.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.slobodnaevropa.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.slotland.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.slsknet.org,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.socom.mil,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -969,6 +1137,10 @@ http://www.stumbleupon.com,GRP,Social Networking,2014-04-15,citizenlab,Updated b
 http://www.stupidcensorship.com,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.submission.org,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.survive.org.uk/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.svaboda.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.svaboda.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+http://www.svoboda.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
+https://www.svoboda.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.systranbox.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.talafone.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.tango.me,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -1021,6 +1193,8 @@ https://www.unicef.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated b
 http://www.unlockme.co.uk,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.unwatch.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.upci.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.urduvoa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.urduvoa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://www.usacasino.com,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.usafa.af.mil,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.usaid.gov/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -1035,7 +1209,55 @@ http://www.vibe.com,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-
 http://www.viber.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.victoriassecret.com/,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.videogamereview.com,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.voaafaanoromoo.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voaafaanoromoo.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voaafrique.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voaafrique.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voabambara.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voabambara.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voabangla.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voabangla.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voacambodia.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voacambodia.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voacantonese.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voacantonese.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voachinese.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voachinese.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voadeewaradio.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voadeewaradio.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voahausa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voahausa.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voaindonesia.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voaindonesia.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voakorea.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voakorea.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voandebele.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voandebele.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://www.voanews.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voanoticias.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voanoticias.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voanouvel.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voanouvel.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voaportugues.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voaportugues.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voashona.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voashona.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voasomali.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voasomali.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voaswahili.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voaswahili.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voathai.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voathai.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voatibetan.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voatibetan.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voatibetanenglish.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voatibetanenglish.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voatiengviet.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voatiengviet.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+http://www.voazimbabwe.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.voazimbabwe.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://www.volcanomail.com,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.vonage.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.wallpapergate.com,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -1091,21 +1313,19 @@ http://www.xroxy.com,ANON,Anonymization and circumvention tools,2014-04-15,citiz
 http://www.xvideos.com/,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2017-08-05
 http://www.xxlmag.com,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.yahoo.com,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+https://www.yelp.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.ymca.int,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.yola.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.youporn.com/,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.youtube.com,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.zeit.de,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.zensur.freerk.com,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.zeriamerikes.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
+https://www.zeriamerikes.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://www.zone-h.org,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.zzn.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www3.iaisite.org/,MILX,Terrorism and Militants,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://xanga.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://xhamster.com/,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://xxx.lanl.gov,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-https://www.yelp.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-https://imageshack.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.bbc.com,NEWS,News Media,2017-07-19,OONI,
-http://www.bbc.co.uk,NEWS,News Media,2017-07-19,OONI,
 http://zoomshare.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-https://www.opentech.fund/,HUMR,Human Rights Issues,2017-09-26,OONI,

--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1041,7 +1041,6 @@ https://www.reproductiverights.org/,HUMR,Human Rights Issues,2014-04-15,citizenl
 http://www.repubblica.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.rescue.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.rfa.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.rfa.org,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
 https://www.rfa.org,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
 http://www.rfa.org/burmese,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
 https://www.rfa.org/burmese,NEWS,News Media,2017-10-06,rfa,Added by GreatFire.org on 2017-10-06
@@ -1066,7 +1065,6 @@ https://www.rfa.org/vietnamese,NEWS,News Media,2017-10-06,rfa,Added by GreatFire
 http://www.rferl.mobi,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 https://www.rferl.mobi,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.rferl.org,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.rferl.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 https://www.rferl.org,NEWS,News Media,2017-10-06,rferl,Added by GreatFire.org on 2017-10-06
 http://www.rfi.fr,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.riftgame.com,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -1234,7 +1232,6 @@ https://www.voakorea.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org o
 http://www.voandebele.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 https://www.voandebele.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://www.voanews.com,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 https://www.voanews.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 http://www.voanoticias.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06
 https://www.voanoticias.com,NEWS,News Media,2017-10-06,voa,Added by GreatFire.org on 2017-10-06


### PR DESCRIPTION
I suggest adding these BBG content URLs for global testing. There's a total of 220 new URLs which are all different editions of RFA, RFERL and VOA. I think it's important to test the availability of all BBG content URLs globally, not just the local language edition, to fully understand the extent of censorship in each location - ie are they blocking one specific URL, most or all of them. Also, the list includes both HTTP and HTTPS versions of each URL. One may be blocked while the other is accessible.

Since this is a major addition, I have auto-sorted the list according to the sorting logic that seemed to be in place in the current list. This means that a few existing URLs have moved to a new position, since they seemed to not have been sorted in the existing version. 