### PR TITLE
Updated BY list

### DIFF
--- a/lists/by.csv
+++ b/lists/by.csv
@@ -182,3 +182,4 @@ http://www.electby.org/,MISC,Miscelaneous content,2017-10-15,igorv,Elections mon
 http://narodny.org/,POLR,Political Criticism,2017-10-15,igorv,
 https://vk.com/stopluka,POLR,Political Criticism,2017-10-15,igorv,
 https://vk.com/l_l_loc,POLR,Political Criticism,2017-10-15,igorv,
+https://www.belaruspartisan.org/,NEWS,News Media,2017-12-16,OONI,


### PR DESCRIPTION
Updated the BY list to include belaruspartisan.org which is ordered to be blocked based on the following order: http://www.mininform.gov.by/ru/news-ru/view/14-dekabrja-2017-g-prinjato-reshenie-ob-ogranichenii-dostupa-k-internet-resursu-belaruspartisanorg-1001/