### PR TITLE
Add fire.news to TW list

### DIFF
--- a/lists/tw.csv
+++ b/lists/tw.csv
@@ -57,6 +57,7 @@ http://new.ctv.com.tw/,NEWS,News Media,2017-08-25,OONI,
 http://www.ttv.com.tw/,NEWS,News Media,2017-08-25,OONI,
 http://www.icrt.com.tw/,NEWS,News Media,2017-08-25,OONI,
 https://tw.news.yahoo.com/,NEWS,News Media,2017-08-25,OONI,
+http://fire.news/,POLR,Political Criticism,2018-01-05,OONI partner, Political commentary by pro-unification groups
 https://www.ptt.cc/bbs/HatePolitics/index.html,POLR,Political Criticism,2017-08-26,OONI partner,
 https://www.tahr.org.tw/,HUMR,Human Rights Issues,2017-08-26,OONI partner,
 http://www.digitaltahr.org.tw/,HUMR,Human Rights Issues,2017-08-26,OONI partner,


### PR DESCRIPTION
fire.news is the political commentary site by pro-chinese-unification groups in Taiwan, mainly the New Party.

Relevant news of recent arrests of New Party members: http://www.taipeitimes.com/News/taiwan/archives/2017/12/23/2003684482