### PR TITLE
Remove the defunct bloglines.com

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -411,7 +411,6 @@ http://www.blacksandjews.com/Welcome.html,HATE,Hate Speech,2014-04-15,citizenlab
 http://www.blizzard.com,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.blogeasy.com,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.blogger.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.bloglines.com,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.blogsome.com,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.blubster.com,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.bme.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Reported by a community member.
See: https://en.wikipedia.org/w/index.php?title=Bloglines&oldid=795961988