### PR TITLE
Remove 911lies.org

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -3,7 +3,6 @@ https://2600.org/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 20
 http://4genderjustice.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://666games.net,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://8thstreetlatinas.com,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://911lies.org,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://a1408.g.akamai.net/5/1408/1388/2005110406/1a1a1ad948be278cff2d96046ad90768d848b41947aa1986/sample_sorenson.mov.zip,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://abpr2.railfan.net,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://addons.mozilla.org,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
This should be deleted as it's no longer active and we have no evidence of it being blocked based on OONI data in any country.
It was reported by a community member.