### PR TITLE
Change GAYL to LGBT in category code list

### DIFF
--- a/lists/00-LEGEND-category_codes.csv
+++ b/lists/00-LEGEND-category_codes.csv
@@ -13,7 +13,7 @@ HAL,"History, arts and literature"
 HATE,Hate speech
 XED,Sex education and family planning
 PUBH,Public health
-GAYL,Gay & lesbian – no pornography
+LGBT,Lesbian-Gay-Bisexual-Transgender community
 PORN,Pornography
 PROV,Provocative attire
 DATE,Online dating


### PR DESCRIPTION
GAYL appears only in the category code lists. In all blocklists, this has already
been changed to LGBT, so there is no need to keep this for backwards
compatibility, whereas keeping it in this file is confusing.

This commit also removes the redundant "no pornography" designation, and
replaces it with "community".