### PR TITLE
lists/ir.csv: Add hdl.handle.net

### DIFF
--- a/lists/ir.csv
+++ b/lists/ir.csv
@@ -969,3 +969,4 @@ http://www.asianangels.com,PORN,Pornography,2017-09-05,OONI,Found to be blocked 
 http://www.linay.com,PROV,Provocative Attire,2017-09-05,OONI,Found to be blocked in Iran based on OONI tests
 http://www.bbcpersian.com,NEWS,News Media,2017-07-19,BBC,
 https://www.radiofarda.com/,NEWS,News Media,2017-09-29,OONI,
+http://hdl.handle.net/10568/91553,SRCH,Search Engines,2018-04-01,Alan Orth,Handle.net provides persistent identifiers for items in academic repositories


### PR DESCRIPTION
Handle.net is a provider of persistent identifiers that are used in academic and institutional repositories. Several users have told me hdl.handle.net links using both both HTTP and HTTPS are inaccessible in Iran.

Closes #322.