### PR TITLE
Add dns.google.com to the global list

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1122,3 +1122,4 @@ https://pastebin.com/,HOST,Hosting and Blogging Platforms,2017-02-12,Anonymous,O
 https://yandex.com/,SRCH,Search Engines,2018-02-23,igorv,
 https://protonmail.com/,HACK,Hacking Tools,2018-03-19,OONI,
 https://getoutline.org/,ANON,Anonymization and circumvention tools,2018-04-06,Duplika,
+https://dns.google.com/,HOST,Hosting and Blogging Platforms,2018-05-02,OONI,


### PR DESCRIPTION
It seems like some are using this as a censorship circumvention strategy (ex. telegram).