### PR TITLE
Update lk.csv 

### DIFF
--- a/lists/lk.csv
+++ b/lists/lk.csv
@@ -50,3 +50,4 @@ https://ikman.lk,COMM,E-commerce,6/21/2018,Community Member,
 http://www.hirufm.lk,MMED,Media sharing,6/21/2018,Community Member,
 https://www.daraz.lk,COMM,E-commerce,6/21/2018,Community Member,
 http://www.gossiplankanews.com,NEWS,News Media,6/21/2018,Community Member,gossip and rumor site
+http://www.manthri.lk,HUMR,Human Rights Issues,6/21/2018,Community Member,MP scorecoard

--- a/lists/lk.csv
+++ b/lists/lk.csv
@@ -1,8 +1,52 @@
 url,category_code,category_description,date_added,source,notes
-http://www.bbc.com/sinhala,NEWS,News Media,2017-07-19,BBC,
-http://www.bbcsinhala.com,NEWS,News Media,2017-07-19,BBC,
-http://www.bbc.com/tamil/,NEWS,News Media,2017-07-19,BBC,
-http://www.bbctamil.com,NEWS,News Media,2017-07-19,BBC,
-http://lankaenews.com/,NEWS,News Media,2017-11-10,citizenlab,Lanka News reported blocked
-http://lankaenews.com/news/2403/en,NEWS,News Media,2017-11-10,citizenlab,
-https://www.yahoo.com/news/dissident-website-blocked-sri-lanka-143729266.html,NEWS,News Media,2017-11-10,citizenlab,
+http://www.bbc.com/sinhala,NEWS,News Media,7/19/2017,BBC,
+http://www.bbcsinhala.com,NEWS,News Media,7/19/2017,BBC,
+http://www.bbc.com/tamil/,NEWS,News Media,7/19/2017,BBC,
+http://www.bbctamil.com,NEWS,News Media,7/19/2017,BBC,
+http://lankaenews.com/,NEWS,News Media,11/10/2017,citizenlab,Lanka News reported blocked
+http://lankaenews.com/news/2403/en,NEWS,News Media,11/10/2017,citizenlab,
+https://www.yahoo.com/news/dissident-website-blocked-sri-lanka-143729266.html,NEWS,News Media,11/10/2017,citizenlab,
+https://www.groundviews.org,NEWS,News Media,6/21/2018,Community Member,
+http://maatram.org/,NEWS,News Media,6/21/2018,Community Member,
+http://www.vikalpa.org/,NEWS,News Media,6/21/2018,Community Member,
+http://www.cpalanka.org/,HUMR,Human Rights Issues,6/21/2018,Community Member,
+http://www.dailymirror.lk/,NEWS,News Media,6/21/2018,Community Member,
+https://www.facebook.com/OccupyColomboTheOfficial/,POLR,Political Criticism,6/21/2018,Community Member,
+http://www.adayaalam.org,HUMR,Human Rights Issues,6/21/2018,Community Member,
+http://www.veriteresearch.org/,HUMR,Human Rights Issues,6/21/2018,Community Member,
+https://www.facebook.com/navamaniofficial/,NEWS,News Media,6/21/2018,Community Member,
+https://en.calameo.com/accounts/4438039,HOST,Hosting and Blogging Platforms,6/21/2018,Community Member,Hosting news content for Navamani. 
+http://www.jdslanka.org/,HUMR,Human Rights Issues,6/21/2018,Community Member,
+https://cmev.org/,HUMR,Human Rights Issues,6/21/2018,Community Member,
+http://www.colombopage.com/,NEWS,News Media,6/21/2018,Community Member,
+http://www.cpalanka.org,HUMR,Human Rights Issues,6/21/2018,Community Member,
+http://www.ft.lk,NEWS,News Media,6/21/2018,Community Member,
+https://www.colombotelegraph.com,NEWS,News Media,6/21/2018,Community Member,
+http://www.lankanewsweb.today,NEWS,News Media,6/21/2018,Community Member,"Domain is down, from Telecommunications Regulatory Commission blocklist published 12/08/2017"
+http://sinhala.lnwtoday.com,NEWS,News Media,6/21/2018,Community Member,"Domain is down, from Telecommunications Regulatory Commission blocklist published 12/08/2017"
+http://www.jilhub.com,PORN,Pornography,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://www.supirikello.com,DATE,Online Dating,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://www.gossipplanets.com/,MISC,Miscellaneous content,6/21/2018,Community Member,"gossip and rumor site, from Telecommunications Regulatory Commission blocklist published 12/08/2017"
+http://www.newjaffna.net/,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://www.vigasapuwath.blogspot.com/2016/08/blog-post_573.html,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+https://vigasapuwath.blogspot.com/2016/08/blog-post_573.html,NEWS,News Media,6/21/2018,Community Member,
+http://www.ukussa.org/2016/08/67,POLR,Political Criticism,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://lankanewsweb.today/archives/12876,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://lankanewsweb.today/archives/5082,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://lankanewsweb.today/archives/8512,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://lankanewsweb.today/archives/8530,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+https://www.mahinda.info/,POLR,Political Criticism,6/21/2018,Community Member,
+https://www.tamilnet.com/,NEWS,News Media,6/21/2018,Community Member,
+https://roar.media/,CULTR,Culture,6/21/2018,Community Member,
+http://www.roar.lk,CULTR,Culture,6/21/2018,Community Member,Redirects to roar.media
+http://www.readme.lk,NEWS,News Media,6/21/2018,Community Member,
+http://www.yamu.lk,CULTR,Culture,6/21/2018,Community Member,
+http://www.lankanewsweb.info,NEWS,News Media,6/21/2018,Community Member,
+https://lankanewsweb.net/,NEWS,News Media,6/21/2018,Community Member,
+http://www.tamilwin.com/,NEWS,News Media,6/21/2018,Community Member,
+http://www.kaymu.lk,COMM,E-commerce,6/21/2018,Community Member,
+https://hirunews.lk,NEWS,News Media,6/21/2018,Community Member,
+https://ikman.lk,COMM,E-commerce,6/21/2018,Community Member,
+http://www.hirufm.lk,MMED,Media sharing,6/21/2018,Community Member,
+https://www.daraz.lk,COMM,E-commerce,6/21/2018,Community Member,
+http://www.gossiplankanews.com,NEWS,News Media,6/21/2018,Community Member,gossip and rumor site

--- a/lists/lk.csv
+++ b/lists/lk.csv
@@ -1,53 +1,52 @@
 url,category_code,category_description,date_added,source,notes
-http://www.bbc.com/sinhala,NEWS,News Media,7/19/2017,BBC,
-http://www.bbcsinhala.com,NEWS,News Media,7/19/2017,BBC,
-http://www.bbc.com/tamil/,NEWS,News Media,7/19/2017,BBC,
-http://www.bbctamil.com,NEWS,News Media,7/19/2017,BBC,
-http://lankaenews.com/,NEWS,News Media,11/10/2017,citizenlab,Lanka News reported blocked
-http://lankaenews.com/news/2403/en,NEWS,News Media,11/10/2017,citizenlab,
-https://www.yahoo.com/news/dissident-website-blocked-sri-lanka-143729266.html,NEWS,News Media,11/10/2017,citizenlab,
-https://www.groundviews.org,NEWS,News Media,6/21/2018,Community Member,
-http://maatram.org/,NEWS,News Media,6/21/2018,Community Member,
-http://www.vikalpa.org/,NEWS,News Media,6/21/2018,Community Member,
-http://www.cpalanka.org/,HUMR,Human Rights Issues,6/21/2018,Community Member,
-http://www.dailymirror.lk/,NEWS,News Media,6/21/2018,Community Member,
-https://www.facebook.com/OccupyColomboTheOfficial/,POLR,Political Criticism,6/21/2018,Community Member,
-http://www.adayaalam.org,HUMR,Human Rights Issues,6/21/2018,Community Member,
-http://www.veriteresearch.org/,HUMR,Human Rights Issues,6/21/2018,Community Member,
-https://www.facebook.com/navamaniofficial/,NEWS,News Media,6/21/2018,Community Member,
-https://en.calameo.com/accounts/4438039,HOST,Hosting and Blogging Platforms,6/21/2018,Community Member,Hosting news content for Navamani. 
-http://www.jdslanka.org/,HUMR,Human Rights Issues,6/21/2018,Community Member,
-https://cmev.org/,HUMR,Human Rights Issues,6/21/2018,Community Member,
-http://www.colombopage.com/,NEWS,News Media,6/21/2018,Community Member,
-http://www.cpalanka.org,HUMR,Human Rights Issues,6/21/2018,Community Member,
-http://www.ft.lk,NEWS,News Media,6/21/2018,Community Member,
-https://www.colombotelegraph.com,NEWS,News Media,6/21/2018,Community Member,
-http://www.lankanewsweb.today,NEWS,News Media,6/21/2018,Community Member,"Domain is down, from Telecommunications Regulatory Commission blocklist published 12/08/2017"
-http://sinhala.lnwtoday.com,NEWS,News Media,6/21/2018,Community Member,"Domain is down, from Telecommunications Regulatory Commission blocklist published 12/08/2017"
-http://www.jilhub.com,PORN,Pornography,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
-http://www.supirikello.com,DATE,Online Dating,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
-http://www.gossipplanets.com/,MISC,Miscellaneous content,6/21/2018,Community Member,"gossip and rumor site, from Telecommunications Regulatory Commission blocklist published 12/08/2017"
-http://www.newjaffna.net/,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
-http://www.vigasapuwath.blogspot.com/2016/08/blog-post_573.html,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
-https://vigasapuwath.blogspot.com/2016/08/blog-post_573.html,NEWS,News Media,6/21/2018,Community Member,
-http://www.ukussa.org/2016/08/67,POLR,Political Criticism,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
-http://lankanewsweb.today/archives/12876,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
-http://lankanewsweb.today/archives/5082,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
-http://lankanewsweb.today/archives/8512,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
-http://lankanewsweb.today/archives/8530,NEWS,News Media,6/21/2018,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
-https://www.mahinda.info/,POLR,Political Criticism,6/21/2018,Community Member,
-https://www.tamilnet.com/,NEWS,News Media,6/21/2018,Community Member,
-https://roar.media/,CULTR,Culture,6/21/2018,Community Member,
-http://www.roar.lk,CULTR,Culture,6/21/2018,Community Member,Redirects to roar.media
-http://www.readme.lk,NEWS,News Media,6/21/2018,Community Member,
-http://www.yamu.lk,CULTR,Culture,6/21/2018,Community Member,
-http://www.lankanewsweb.info,NEWS,News Media,6/21/2018,Community Member,
-https://lankanewsweb.net/,NEWS,News Media,6/21/2018,Community Member,
-http://www.tamilwin.com/,NEWS,News Media,6/21/2018,Community Member,
-http://www.kaymu.lk,COMM,E-commerce,6/21/2018,Community Member,
-https://hirunews.lk,NEWS,News Media,6/21/2018,Community Member,
-https://ikman.lk,COMM,E-commerce,6/21/2018,Community Member,
-http://www.hirufm.lk,MMED,Media sharing,6/21/2018,Community Member,
-https://www.daraz.lk,COMM,E-commerce,6/21/2018,Community Member,
-http://www.gossiplankanews.com,NEWS,News Media,6/21/2018,Community Member,gossip and rumor site
-http://www.manthri.lk,HUMR,Human Rights Issues,6/21/2018,Community Member,MP scorecoard
+http://www.bbc.com/sinhala,NEWS,News Media,2017-07-19,BBC,
+http://www.bbcsinhala.com,NEWS,News Media,2017-07-19,BBC,
+http://www.bbc.com/tamil/,NEWS,News Media,2017-07-19,BBC,
+http://www.bbctamil.com,NEWS,News Media,2017-07-19,BBC,
+http://lankaenews.com/,NEWS,News Media,2017-11-10,citizenlab,Lanka News reported blocked
+http://lankaenews.com/news/2403/en,NEWS,News Media,2017-11-10,citizenlab,
+https://www.yahoo.com/news/dissident-website-blocked-sri-lanka-143729266.html,NEWS,News Media,2017-11-10,citizenlab,
+https://www.groundviews.org,NEWS,News Media,2018-06-21,Community Member,
+http://maatram.org/,NEWS,News Media,2018-06-21,Community Member,
+http://www.vikalpa.org/,NEWS,News Media,2018-06-21,Community Member,
+http://www.dailymirror.lk/,NEWS,News Media,2018-06-21,Community Member,
+https://www.facebook.com/OccupyColomboTheOfficial/,POLR,Political Criticism,2018-06-21,Community Member,
+http://www.adayaalam.org,HUMR,Human Rights Issues,2018-06-21,Community Member,
+http://www.veriteresearch.org/,HUMR,Human Rights Issues,2018-06-21,Community Member,
+https://www.facebook.com/navamaniofficial/,NEWS,News Media,2018-06-21,Community Member,
+https://en.calameo.com/accounts/4438039,HOST,Hosting and Blogging Platforms,2018-06-21,Community Member,Hosting news content for Navamani. 
+http://www.jdslanka.org/,HUMR,Human Rights Issues,2018-06-21,Community Member,
+https://cmev.org/,HUMR,Human Rights Issues,2018-06-21,Community Member,
+http://www.colombopage.com/,NEWS,News Media,2018-06-21,Community Member,
+http://www.cpalanka.org,HUMR,Human Rights Issues,2018-06-21,Community Member,
+http://www.ft.lk,NEWS,News Media,2018-06-21,Community Member,
+https://www.colombotelegraph.com,NEWS,News Media,2018-06-21,Community Member,
+http://www.lankanewsweb.today,NEWS,News Media,2018-06-21,Community Member,"Domain is down, from Telecommunications Regulatory Commission blocklist published 12/08/2017"
+http://sinhala.lnwtoday.com,NEWS,News Media,2018-06-21,Community Member,"Domain is down, from Telecommunications Regulatory Commission blocklist published 12/08/2017"
+http://www.jilhub.com,PORN,Pornography,2018-06-21,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://www.supirikello.com,DATE,Online Dating,2018-06-21,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://www.gossipplanets.com/,MISC,Miscelaneous content,2018-06-21,Community Member,"gossip and rumor site, from Telecommunications Regulatory Commission blocklist published 12/08/2017"
+http://www.newjaffna.net/,NEWS,News Media,2018-06-21,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://www.vigasapuwath.blogspot.com/2016/08/blog-post_573.html,NEWS,News Media,2018-06-21,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+https://vigasapuwath.blogspot.com/2016/08/blog-post_573.html,NEWS,News Media,2018-06-21,Community Member,
+http://www.ukussa.org/2016/08/67,POLR,Political Criticism,2018-06-21,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://lankanewsweb.today/archives/12876,NEWS,News Media,2018-06-21,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://lankanewsweb.today/archives/5082,NEWS,News Media,2018-06-21,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://lankanewsweb.today/archives/8512,NEWS,News Media,2018-06-21,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+http://lankanewsweb.today/archives/8530,NEWS,News Media,2018-06-21,Community Member,From Telecommunications Regulatory Commission blocklist published 12/08/2017
+https://www.mahinda.info/,POLR,Political Criticism,2018-06-21,Community Member,
+https://www.tamilnet.com/,NEWS,News Media,2018-06-21,Community Member,
+https://roar.media/,CULTR,Culture,2018-06-21,Community Member,
+http://www.roar.lk,CULTR,Culture,2018-06-21,Community Member,Redirects to roar.media
+http://www.readme.lk,NEWS,News Media,2018-06-21,Community Member,
+http://www.yamu.lk,CULTR,Culture,2018-06-21,Community Member,
+http://www.lankanewsweb.info,NEWS,News Media,2018-06-21,Community Member,
+https://lankanewsweb.net/,NEWS,News Media,2018-06-21,Community Member,
+http://www.tamilwin.com/,NEWS,News Media,2018-06-21,Community Member,
+http://www.kaymu.lk,COMM,E-commerce,2018-06-21,Community Member,
+https://hirunews.lk,NEWS,News Media,2018-06-21,Community Member,
+https://ikman.lk,COMM,E-commerce,2018-06-21,Community Member,
+http://www.hirufm.lk,MMED,Media sharing,2018-06-21,Community Member,
+https://www.daraz.lk,COMM,E-commerce,2018-06-21,Community Member,
+http://www.gossiplankanews.com,NEWS,News Media,2018-06-21,Community Member,gossip and rumor site
+http://www.manthri.lk,HUMR,Human Rights Issues,2018-06-21,Community Member,MP scorecoard


### PR DESCRIPTION
Added NGO and social media websites from the [ 2017 Freedom on the Net Report](https://freedomhouse.org/report/freedom-net/2017/sri-lanka), URLs that [Groundviews reported](https://groundviews.org/2017/12/08/blocked-rti-requests-reveal-process-behind-blocking-of-websites-in-sri-lanka/) were blocked in December 2017, and other news media websites. 