### PR TITLE
Add Cloudflare and Quad9 DNS over HTTPS servers.

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1136,6 +1136,11 @@ https://getoutline.org/,ANON,Anonymization and circumvention tools,2018-04-06,Du
 http://fteproxy.org/,ANON,Anonymization and circumvention tools,2018-05-21,Community member,
 https://www.thegeekdiary.com/,HACK,Hacking Tools,2018-05-21,Community member,
 https://dns.google.com/,HOST,Hosting and Blogging Platforms,2018-05-02,OONI,
+https://cloudflare-dns.com/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,Hosting and Blogging Platforms,2018-10-16,David Fifield,Cloudflare DNS over HTTPS; query is for www.example.com: https://developers.cloudflare.com/1.1.1.1/dns-over-https/wireformat/#using-get
+https://1.1.1.1/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,Hosting and Blogging Platforms,2018-10-16,David Fifield,Cloudflare DNS over HTTPS; query is for www.example.com. https://developers.cloudflare.com/1.1.1.1/dns-over-https/wireformat/#using-get
+https://1.0.0.1/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,Hosting and Blogging Platforms,2018-10-16,David Fifield,Cloudflare DNS over HTTPS; query is for www.example.com. https://developers.cloudflare.com/1.1.1.1/dns-over-https/wireformat/#using-get
+https://dns.quad9.net/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,Hosting and Blogging Platforms,2018-10-16,David Fifield,Quad9 DNS over HTTPS; query is for www.example.com. https://quad9.com/doh-quad9-dns-servers/
+https://9.9.9.9/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,Hosting and Blogging Platforms,2018-10-16,David Fifield,Quad9 DNS over HTTPS; query is for www.example.com. https://quad9.com/doh-quad9-dns-servers/
 https://soundcloud.com/,CULTR,Culture,2018-07-23,OONI,
 https://signal.org/,COMT,Communication Tools,2018-04-19,OONI,
 https://www.tunnelbear.com/,ANON,Anonymization and circumvention tools,2018-04-19,OONI,


### PR DESCRIPTION
These complement the existing https://dns.google.com/. For these new
ones, I added a path and query string that actually does a lookup for
www.example.com, rather than pointing at their landing page.

Besides their memorable IPv4 address, these services also have IPv6
addresses. But as far as I can tell, there are no existing URLs with
literal IPv6 addresses. Additional addresses, not added by this patch,
are:

Quad9
	149.112.112.112
	2620:fe::fe
	2620:fe::9

Cloudflare
	2606:4700:4700::1111
	2606:4700:4700::1001

In lookup up these providers, I also found
https://cleanbrowsing.org/dnsoverhttps operating a public DNS over HTTPS
server.