### PR TITLE
added missing country code

### DIFF
--- a/lists/00-LEGEND-country_codes.csv
+++ b/lists/00-LEGEND-country_codes.csv
@@ -37,6 +37,7 @@ BY,Belarus
 BZ,Belize
 CA,Canada
 CC,Cocos (Keeling) Islands
+CD,Democratic Republic of the Congo
 CF,Central African Republic
 CG,Congo
 CH,Switzerland


### PR DESCRIPTION
added missing country code of the Democratic Republic of the Congo, as the list contains only the code of the neighboring country with a similar name - the Republic of the Congo. They are two different countries.