### PR TITLE
Added thepiratebay.org

### DIFF
--- a/lists/nl.csv
+++ b/lists/nl.csv
@@ -3,3 +3,4 @@ https://nl.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wi
 https://meta.wikimedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://tr.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://fa.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
+https://thepiratebay.org/,FILE,File sharing,2019-06-04

--- a/lists/nl.csv
+++ b/lists/nl.csv
@@ -3,4 +3,4 @@ https://nl.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wi
 https://meta.wikimedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://tr.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://fa.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
-https://thepiratebay.org/,FILE,File sharing,2019-06-04
+https://thepiratebay.org/,FILE,File sharing,2019-04-06


### PR DESCRIPTION
thepiratebay.org is a known censored domain in The Netherlands.