### PR TITLE
Add sci-hub.to to German list

### DIFF
--- a/lists/de.csv
+++ b/lists/de.csv
@@ -7,3 +7,4 @@ https://s.to/,MMED,Media sharing,2019-04-25,Anonymous,Blocked URL
 https://bs.to/,MMED,Media sharing,2019-04-25,Anonymous,Blocked URL
 https://boerse.to/,MMED,Media sharing,2019-04-25,Anonymous,Blocked URL
 https://gen.lib.rus.ec/,CULTR,Culture,2019-04-25,Anonymous,Blocked URL
+https://sci-hub.tw/,CULTR,Culture,2019-07-29,Community member,Blocked in networks of Vodafone (according to several reports and personal tests)


### PR DESCRIPTION
Personal tests and several unrelated sources report that sci-hub.tw is
blocked via DNS in networks of Vodafone at least since December 2017.

Sources:
- https://twitter.com/reinhardremfort/status/938688543572054016
- https://forum.golem.de/kommentare/internet/sci-hub-schwedischer-isp-blockt-elsevier-nach-blockieraufforderung/vodafone-wlan-hotspot-blockt-sci-hub.tw-ebenfalls/121776,5223229,5223229,read.html
- https://www.reddit.com/r/de/comments/8vr8vd/was_zur_h%C3%B6lle_l%C3%A4uft_bei_vodafone_schief/e1pt9yd/
- https://netzpolitik.org/2018/netzsperren-vodafone-muss-kinox-to-blockieren-und-kundendaten-speichern/#comment-2429563
- https://www.heise.de/forum/heise-online/News-Kommentare/Aus-Protest-Schwedischer-Provider-blockiert-Elsevier/In-Deutschland-sperrt-Vodafone-den-Zugriff-auf-Sci-Hub/posting-33375681/show/