### PR TITLE
Add GitHub government takedown requests

### DIFF
--- a/lists/cn.csv
+++ b/lists/cn.csv
@@ -239,3 +239,4 @@ http://zh.globalvoicesonline.org/hant/category/world/east-asia/china/,NEWS,News 
 https://matters.news/,HOST,Hosting and Blogging Platforms,2019-05-30,shenzhenlug,
 https://matrix.org/,COMT,Communication Tools,2019-05-30,shenzhenlug,
 https://zh.wikinews.org/,CULTR,Culture,2019-05-02,Wikimedia,URLs provided by Wikipedia based on recent censorship events
+https://github.com/programthink/zhao/issues/38,POLR,Political Criticism,2019-08-06,,GitHub government takedown notice from 2016-06-08

--- a/lists/ru.csv
+++ b/lists/ru.csv
@@ -311,3 +311,34 @@ https://www.svoboda.org/,NEWS,News Media,2018-09-13,OONI,
 https://ru.m.wikipedia.org/,CULTR,Culture,2019-02-19,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://ru.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://ru.m.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
+https://github.com/russian-suicide/ololo,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
+https://github.com/muromec/blog/blob/d0a4b73064b0d2306a6184b75c9bbfeb3daa2a00/repost/suicide.rst,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
+https://github.com/numitus/objidlib/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
+https://github.com/samm-git/objidlib/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
+https://github.com/l29ah/objidlib/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
+https://github.com/kleonov/some-text/,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
+https://raw.githubusercontent.com/stevebest/suicide/master/suicide.md,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-11-27
+https://github.com/IronKaput/sepulckis,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-12-19
+http://fast-die.github.io/,COMM,E-commerce,2019-08-06,,GitHub government takedown notice from 2015-07-22
+https://github.com/Alex0007/crimea-ozpp/blob/master/README.md,POLR,Political Criticism,2019-08-06,,GitHub government takedown notice from 2016-02-16
+https://gist.github.com/firedev/074a3ebe3dfc7f5ad8f8,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2016-07-07
+https://github.com/betcity/config,FILE,File-sharing,2019-08-06,,GitHub government takedown notice from 2016-08-31
+https://github.com/developerivanov3000/MyFirstApp/raw/master/Zenit.msi,FILE,File-sharing,2019-08-06,,GitHub government takedown notice from 2017-01-18
+https://github.com/alexpastuh/new_proj/raw/master/Zenit.msi,FILE,File-sharing,2019-08-06,,GitHub government takedown notice from 2017-02-08
+https://leonaccess.github.io/,GMB,Gambling,2019-08-06,,GitHub government takedown notice from 2017-04-13
+https://bannerproxy.github.io/ru/anonymizer,ANON,Anonymization and circumvention tools,2019-08-06,,GitHub government takedown notice from 2017-07-18
+https://raw.githubusercontent.com/bcnv001/cnfg/master/sources/sources_enc.json,FILE,File-sharing,2019-08-06,,GitHub government takedown notice from 2017-08-18
+https://bbproxy.github.io/,ANON,Anonymization and circumvention tools,2019-08-06,,GitHub government takedown notice from 2017-09-15
+https://github.com/amdf/objidlib/commit/643077865e390f1eccacf9620199772e1e468a4a,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2017-11-01
+https://github.com/fbdevdata/psipl,FILE,File-sharing,2019-08-06,,GitHub government takedown notice from 2018-02-01
+https://gist.githubusercontent.com/mjr27/ff6c3ebb190b27941ad3/raw/3a6b885d4be0d105b628ef3d8ecc517026d98ac9/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-03-13
+https://github.com/ValdikSS/objidlib/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-06-13
+https://gist.github.com/dominicusin/ac85f3f149f61b861347ebcebdb5caa7,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-10-22
+https://github.com/andriyanov/suicide/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-10-22
+https://gist.github.com/border-radius/80b7da7d5f01b9c2419d,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-10-22
+https://gist.github.com/MrZoidberg/b92647c73600ef1e8d8d,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-10-22
+http://mdz-rus.github.io/,MISC,Miscelaneous content,2019-08-06,,GitHub government takedown notice from 2018-10-24
+https://github.com/donkaban/XShot/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2019-07-25
+https://gist.github.com/ojab/b6345333147279321f1d,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2019-07-25
+https://thesnipergodproxy.github.io/ru/anonymizer,ANON,Anonymization and circumvention tools,2019-08-06,,GitHub government takedown notice from 2019-07-31
+https://cherurg.github.io/investing-coins/,ECON,Economics,2019-08-06,,GitHub government takedown notice from 2019-08-05

--- a/lists/ru.csv
+++ b/lists/ru.csv
@@ -311,32 +311,12 @@ https://www.svoboda.org/,NEWS,News Media,2018-09-13,OONI,
 https://ru.m.wikipedia.org/,CULTR,Culture,2019-02-19,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://ru.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://ru.m.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
-https://github.com/russian-suicide/ololo,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
-https://github.com/muromec/blog/blob/d0a4b73064b0d2306a6184b75c9bbfeb3daa2a00/repost/suicide.rst,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
-https://github.com/numitus/objidlib/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
-https://github.com/samm-git/objidlib/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
-https://github.com/l29ah/objidlib/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
-https://github.com/kleonov/some-text/,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-10-21
-https://raw.githubusercontent.com/stevebest/suicide/master/suicide.md,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-11-27
-https://github.com/IronKaput/sepulckis,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2014-12-19
 http://fast-die.github.io/,COMM,E-commerce,2019-08-06,,GitHub government takedown notice from 2015-07-22
-https://github.com/Alex0007/crimea-ozpp/blob/master/README.md,POLR,Political Criticism,2019-08-06,,GitHub government takedown notice from 2016-02-16
-https://gist.github.com/firedev/074a3ebe3dfc7f5ad8f8,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2016-07-07
-https://github.com/betcity/config,FILE,File-sharing,2019-08-06,,GitHub government takedown notice from 2016-08-31
-https://github.com/developerivanov3000/MyFirstApp/raw/master/Zenit.msi,FILE,File-sharing,2019-08-06,,GitHub government takedown notice from 2017-01-18
-https://github.com/alexpastuh/new_proj/raw/master/Zenit.msi,FILE,File-sharing,2019-08-06,,GitHub government takedown notice from 2017-02-08
 https://leonaccess.github.io/,GMB,Gambling,2019-08-06,,GitHub government takedown notice from 2017-04-13
 https://bannerproxy.github.io/ru/anonymizer,ANON,Anonymization and circumvention tools,2019-08-06,,GitHub government takedown notice from 2017-07-18
 https://raw.githubusercontent.com/bcnv001/cnfg/master/sources/sources_enc.json,FILE,File-sharing,2019-08-06,,GitHub government takedown notice from 2017-08-18
 https://bbproxy.github.io/,ANON,Anonymization and circumvention tools,2019-08-06,,GitHub government takedown notice from 2017-09-15
-https://github.com/amdf/objidlib/commit/643077865e390f1eccacf9620199772e1e468a4a,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2017-11-01
-https://github.com/fbdevdata/psipl,FILE,File-sharing,2019-08-06,,GitHub government takedown notice from 2018-02-01
 https://gist.githubusercontent.com/mjr27/ff6c3ebb190b27941ad3/raw/3a6b885d4be0d105b628ef3d8ecc517026d98ac9/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-03-13
-https://github.com/ValdikSS/objidlib/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-06-13
-https://gist.github.com/dominicusin/ac85f3f149f61b861347ebcebdb5caa7,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-10-22
-https://github.com/andriyanov/suicide/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-10-22
-https://gist.github.com/border-radius/80b7da7d5f01b9c2419d,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-10-22
-https://gist.github.com/MrZoidberg/b92647c73600ef1e8d8d,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2018-10-22
 http://mdz-rus.github.io/,MISC,Miscelaneous content,2019-08-06,,GitHub government takedown notice from 2018-10-24
 https://github.com/donkaban/XShot/blob/master/suicide.txt,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2019-07-25
 https://gist.github.com/ojab/b6345333147279321f1d,PUBH,Public Health,2019-08-06,,GitHub government takedown notice from 2019-07-25


### PR DESCRIPTION
Manually added by looking at the official GitHub repository for
government takedown requests at https://github.com/github/gov-takedowns

The URLs were mostly retrieved via following command (with GNU grep)
from within the cloned GitHub repository:

    grep -roP --exclude-dir='.?*' 'https?://.*? ' . | sort | uniq | grep -v http://eais.rkn.gov.ru

URLs which lead to HTTP 404 errors, and thus cannot be categorized properly, were omitted (currently 5).

Although the Russian takedown requests announce that the offending URLs will be added to the "Unified register of the domain names, website references and network addresses that allow identifying websites containing information circulation of which is forbidden in the Russian Federation", only a few are listed there (mostly the newer ones from 2019). Therefore this PR is somewhat related to issue #16 This can be checked here: http://eais.rkn.gov.ru/en/

The mapping to the categories are highly subjective, therefore feedback is more than welcome!