### PR TITLE
Add some URLs from Turkish court order

### DIFF
--- a/lists/tr.csv
+++ b/lists/tr.csv
@@ -185,13 +185,13 @@ http://geziyisavunuyoruz.org/,POLR,Political Criticism,2019-08-06,,Ankara 3rd Cr
 https://www.gazetefersude.com/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
 https://yenidemokratgenclik1.com/,POLR,Political Criticism,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
 http://umutgazetesi14.org/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
-http://kizilbayrak44.net/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
-http://marksistteori.org/,POLR,Political Criticism,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://kizilbayrak44.net/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://marksistteori.org/,POLR,Political Criticism,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
 http://direnisteyiz26.org/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
-http://mucadelebirligi6.net/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://mucadelebirligi6.net/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
 https://www.perisearch.xyz/user/halkinsesitvrdy,SRCH,Search Engines,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
 https://www.pscp.tv/halkinsesitvrdy/1djGXpwyvwLGZ,GRP,Social Networking,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
-http://antakyasokak.e-monsite.com/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://antakyasokak.e-monsite.com/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
 https://tr.pinterest.com/sambasuzi,MMED,Media sharing,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
 https://www.instagram.com/denizlerin_sevdasym,GRP,Social Networking,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
 https://www.youtube.com/channel/UCc1U-ynSUyDqEVS66TvbNOg,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538

--- a/lists/tr.csv
+++ b/lists/tr.csv
@@ -178,3 +178,20 @@ https://www.bbc.com/turkce,NEWS,News Media,2018-09-13,OONI,
 https://www.dw.com/tr/,NEWS,News Media,2018-09-13,OONI,
 https://tr.sputniknews.com/,NEWS,News Media,2018-09-13,OONI,
 https://www.amerikaninsesi.com/,NEWS,News Media,2018-09-13,OONI,
+http://etha10.com/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://ozgurgelecek17.net/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+http://osp.org.tr/,POLR,Political Criticism,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+http://geziyisavunuyoruz.org/,POLR,Political Criticism,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://www.gazetefersude.com/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://yenidemokratgenclik1.com/,POLR,Political Criticism,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+http://umutgazetesi14.org/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+http://kizilbayrak44.net/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+http://marksistteori.org/,POLR,Political Criticism,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+http://direnisteyiz26.org/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+http://mucadelebirligi6.net/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://www.perisearch.xyz/user/halkinsesitvrdy,SRCH,Search Engines,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://www.pscp.tv/halkinsesitvrdy/1djGXpwyvwLGZ,GRP,Social Networking,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+http://antakyasokak.e-monsite.com/,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://tr.pinterest.com/sambasuzi,MMED,Media sharing,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://www.instagram.com/denizlerin_sevdasym,GRP,Social Networking,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538
+https://www.youtube.com/channel/UCc1U-ynSUyDqEVS66TvbNOg,NEWS,News Media,2019-08-06,,Ankara 3rd Criminal Judgeship of Peace court order 2019/5538


### PR DESCRIPTION
Today a court order from the Ankara 3rd Criminal Judgeship of Peace
(order no. 2019/5538) was leaked which lists 136 URLs that are ordered
to be blocked in Turkey.

Sources:
- https://bianet.org/system/uploads/1/files/attachments/000/002/687/original/Ankara_3rd_Criminal_Judgeship_of_Peace_2019-5538_Misc..pdf?1565091519
- https://bianet.org/bianet/ifade-ozgurlugu/211382-bianet-in-tum-icerigine-engelleme-karari
- https://umutgazetesi15.org/arsivler/18356
- https://www.zeit.de/politik/ausland/2019-08/internetzensur-tuerkei-oppositionelle-webseiten-sperrung

Only non-duplicate domains and working URLs were added.