### PR TITLE
Removed Aljazeera from local lists

### DIFF
--- a/lists/eg.csv
+++ b/lists/eg.csv
@@ -141,7 +141,6 @@ https://www.akhbarelyom.com/,NEWS,News Media,2018-02-09,OONI,This news website i
 https://www.alamatonline.com/,NEWS,News Media,2017-07-01,AFTE,Reportedly blocked
 https://www.albawabhnews.com/,NEWS,News Media,2018-02-09,OONI,
 https://www.alborsanews.com/,NEWS,News Media,2017-05-28,ADEF,blocked as of date added
-https://www.aljazeera.com/,NEWS,News Media,2014-04-15,citizenlab,Reportedly blocked
 https://www.aljazeera.net/portal,NEWS,News Media,2014-04-15,citizenlab,Reportedly blocked
 https://www.almasryalyoum.com/,NEWS,News Media,2018-02-09,OONI,
 https://www.defenceweb.co.za/,NEWS,News Media,2017-08-07,AFTE,

--- a/lists/sa.csv
+++ b/lists/sa.csv
@@ -360,9 +360,7 @@ https://www.alarab.qa/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 https://www.gulf-times.com/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 https://thepeninsulaqatar.com/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 https://www.mofa.gov.qa/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
-https://www.aljazeera.net/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 http://doc.aljazeera.net/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
-https://www.aljazeera.com/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 https://www.qatarairways.com/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 http://www.qu.edu.qa/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 http://www.qtv.qa/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned

--- a/lists/ye.csv
+++ b/lists/ye.csv
@@ -560,7 +560,6 @@ https://www.gulf-times.com/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 https://thepeninsulaqatar.com/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 https://www.mofa.gov.qa/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 http://doc.aljazeera.net/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
-https://www.aljazeera.com/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 https://www.qatarairways.com/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 http://www.qu.edu.qa/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
 http://www.qtv.qa/,NEWS,News Media,2019-05-02,Netalitica,Qatar-aligned
@@ -799,7 +798,6 @@ https://www.yemenakhbar.com/,NEWS,News Media,2016-04-18,citizenlab,Local media
 https://www.yemensaeed.net/,NEWS,News Media,2016-04-18,citizenlab,Local media
 https://www.yemensky.com/,NEWS,News Media,2016-04-18,citizenlab,Local media
 https://www.yemenvoice.net/,NEWS,News Media,2016-04-18,citizenlab,Local media
-https://www.aljazeera.net/,NEWS,News Media,2016-04-18,citizenlab,
 https://almadaniya.net/,NEWS,News Media,2016-04-18,citizenlab,Local media
 https://www.alwatan.com.sa/,NEWS,News Media,2016-04-18,citizenlab,Local media
 https://freedom-ye.com/,NEWS,News Media,2016-04-18,citizenlab,Local media


### PR DESCRIPTION
Aljazeera domains (aljazeera.com & aljazeera.net) have been added to the global test list (#510), which means they shouldn't be included in country lists as well (the CI checks won't pass if duplicate URLs are included across test lists).

I have therefore opened this PR to remove aljazeera domains from local test lists.

@sneft Merging this PR is a prerequisite to merging #510. 