### PR TITLE
Add more sites to the FR list

### DIFF
--- a/lists/fr.csv
+++ b/lists/fr.csv
@@ -16,3 +16,6 @@ https://pl.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wi
 https://fr.m.wikipedia.org/,CULTR,Culture,2019-02-19,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://fr.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://fr.m.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
+https://libgen.is/,FILE,File-sharing,2019-09-27,Community Member,Libgen was blocked in France from April 2019 https://www.numerama.com/sciences/477218-sci-hub-et-libgen-luttent-pour-la-diffusion-gratuite-du-savoir-scientifique-la-france-ordonne-leur-blocage.html
+https://nantes.indymedia.org/,FEXP,Freedom of expression and media freedom,2019-09-27,Community Member,Independent media threatened to be blocked by the police https://nantes.indymedia.org/articles/44313
+https://grenoble.indymedia.org/,FEXP,Freedom of expression and media freedom,2019-09-27,Community Member,Independent media threatened to be blocked by the police

--- a/lists/fr.csv
+++ b/lists/fr.csv
@@ -17,5 +17,5 @@ https://fr.m.wikipedia.org/,CULTR,Culture,2019-02-19,Wikimedia,URLs provided by 
 https://fr.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://fr.m.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://libgen.is/,FILE,File-sharing,2019-09-27,Community Member,Libgen was blocked in France from April 2019 https://www.numerama.com/sciences/477218-sci-hub-et-libgen-luttent-pour-la-diffusion-gratuite-du-savoir-scientifique-la-france-ordonne-leur-blocage.html
-https://nantes.indymedia.org/,FEXP,Freedom of expression and media freedom,2019-09-27,Community Member,Independent media threatened to be blocked by the police https://nantes.indymedia.org/articles/44313
-https://grenoble.indymedia.org/,FEXP,Freedom of expression and media freedom,2019-09-27,Community Member,Independent media threatened to be blocked by the police
+https://nantes.indymedia.org/,NEWS,News Media,2019-09-27,Community Member,Independent media threatened to be blocked by the police https://nantes.indymedia.org/articles/44313
+https://grenoble.indymedia.org/,NEWS,News Media,2019-09-27,Community Member,Independent media threatened to be blocked by the police


### PR DESCRIPTION
Hi,

Here are a few more websites interesting to track for France :
* https://libgen.is/ is an website giving free access to scientific research, it was blocked by main French ISP in April 2019 ([ref](https://www.numerama.com/sciences/477218-sci-hub-et-libgen-luttent-pour-la-diffusion-gratuite-du-savoir-scientifique-la-france-ordonne-leur-blocage.html))
* https://grenoble.indymedia.org/ and https://nantes.indymedia.org/ are independent media websites that were threatened to be blocked by the police in January 2019 ([ref](https://nantes.indymedia.org/articles/44313))

Let me know if this PR is okay