### PR TITLE
mongolia list header typo

### DIFF
--- a/lists/mn.csv
+++ b/lists/mn.csv
@@ -1,4 +1,4 @@
-url,category_code,category_description,date_aded,source,notes
+url,category_code,category_description,date_added,source,notes
 http://123moviesfreez.com/,FILE,File-sharing,2017-06-23,OONI,Included in Mongolia's official blocklist
 http://16honeys.com/,PORN,Pornography,2017-06-23,OONI,Included in Mongolia's official blocklist
 http://nice44kino.info/,CULTR,Culture,2017-06-23,OONI,Included in Mongolia's official blocklist


### PR DESCRIPTION
Minor fix - Header for the mongolia list was inconsistent with the other headers

date_aded != date_added

The linter should probably be added to look for this, though the rest of the repo is fine.