### PR TITLE
Removed blank Nicaragua list (.ni) 

### DIFF
--- a/lists/ni.csv
+++ b/lists/ni.csv
@@ -1,1 +1,0 @@
-url,category_code,category_description,date_added,source,notes


### PR DESCRIPTION
There are no URLs in the Nicaragua list (.ni) list, I believe it should either have a URL added or the list should be removed entirely (this PR).  If this is accepted I can add this logic to the linter as well (that lists should have at least a single URL)

Cheers,
Jakub