### PR TITLE
Add new censored domains in Spain at 18th Oct 2019

### DIFF
--- a/lists/es.csv
+++ b/lists/es.csv
@@ -33,3 +33,13 @@ https://referendum.clash.cat/,POLR,Political Criticism,2017-09-25,OONI,referendu
 https://marianorajoy.clash.cat/,POLR,Political Criticism,2017-09-25,OONI,referendum in Catalonia
 https://eu.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://gl.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
+https://tsunamidemocratic.cat,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://app.tsunamidemocratic.cat,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://tsdem.org,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://api.tsdem.org,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://app.tsdem.org,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://tsunamidemocratic.net,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://tsunamidemocratic.com,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://app.tsunamidemocratic.com,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://tsunamidemocratic.github.io/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://democratictsunami.eu/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum

--- a/lists/es.csv
+++ b/lists/es.csv
@@ -33,13 +33,13 @@ https://referendum.clash.cat/,POLR,Political Criticism,2017-09-25,OONI,referendu
 https://marianorajoy.clash.cat/,POLR,Political Criticism,2017-09-25,OONI,referendum in Catalonia
 https://eu.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://gl.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
-https://tsunamidemocratic.cat,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
-https://app.tsunamidemocratic.cat,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
-https://tsdem.org,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
-https://api.tsdem.org,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
-https://app.tsdem.org,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
-https://tsunamidemocratic.net,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
-https://tsunamidemocratic.com,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
-https://app.tsunamidemocratic.com,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://tsunamidemocratic.cat/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://app.tsunamidemocratic.cat/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://tsdem.org/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://api.tsdem.org/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://app.tsdem.org/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://tsunamidemocratic.net/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://tsunamidemocratic.com/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
+https://app.tsunamidemocratic.com/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
 https://tsunamidemocratic.github.io/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum
 https://democratictsunami.eu/,POLR,Political Criticism,2019-10-21,user contribution,Protests in Catalonia against jail sentence for governing politicians during referendum


### PR DESCRIPTION
These domains were banned using the services of allot.com the day of the General Strike of 18th of October.
The strike demanded working rights, but mainly protested against the jail sentence of the leaders of catalan interdependentist parties, started at 2017 after the prohibited independence referendum.

Tsunami democratic is the name of a hidden group of activists that gained the support of indenpendentist parties and that succeed at its call for blocking the Barcelona airport the 14th of October (the monday before the censorship) https://www.theguardian.com/world/2019/oct/18/new-generation-new-tactics-the-changing-face-of-catalan-protests

The kind of censorship appears to be different from that of October 2017: Then it was with DNS hijack, today DNS appears to stay ok, but with help of Allot.com they answers censored TCP replies (as the TLS cert is also fake)

More political context: https://www.theguardian.com/commentisfree/2019/oct/15/catalonia-separatists-jailed-sedition-hubris
Article on the web censorship in catalan: https://www.vilaweb.cat/noticies/la-guardia-civil-ordena-el-blocatge-de-les-webs-del-tsunami-democratic/