### PR TITLE
Add websites issued to be blocked by court in Brasil

### DIFF
--- a/lists/br.csv
+++ b/lists/br.csv
@@ -2770,3 +2770,14 @@ https://anis.org.br/sobre/,XED,Sex Education,2019-09-05,OONI,
 https://uterolivre.milharal.org/,XED,Sex Education,2019-09-06,Coding Rights,
 https://somostodasclandestinas.milharal.org/,XED,Sex Education,2019-09-06,Coding Rights,
 https://paratodasnos.red/,XED,Sex Education,2019-09-06,Coding Rights,
+http://akugyash.com/,HOST,Hosting and Blogging Platforms,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166
+http://alfastream.cc/,FILE,File-sharing,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166
+http://centrelinguistique.com/,COMM,E-commerce,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166
+http://clipwatching.com/,MMED,Media sharing,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166
+http://oload.tv/,FILE,File-sharing,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166
+http://ruvid.nl/,MMED,Media sharing,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166
+http://verystream.net/,FILE,File-sharing,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166
+http://videoshare.club/,FILE,File-sharing,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166
+https://mega.nz/,FILE,File-sharing,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166
+https://openload.co/,FILE,File-sharing,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166
+https://www.fembed.net/,MMED,Media sharing,2019-10-21,magma,https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166


### PR DESCRIPTION
São Paulo Court of Justice website blocking order on September 12, 2019:
https://web.archive.org/save/https://www.jusbrasil.com.br/diarios/261303463/djsp-judicial-1a-instancia-capital-12-09-2019-pg-1166