### PR TITLE
Remove Slate from PK test list

### DIFF
--- a/lists/pk.csv
+++ b/lists/pk.csv
@@ -238,7 +238,6 @@ http://baluch.com/,NEWS,News Media,2019-08-02,Netalitica,Can be blocked due to c
 https://www.indiatoday.in/,NEWS,News Media,2019-08-02,Netalitica,Indian News Website
 https://www.pressreader.com/,NEWS,News Media,2019-08-02,Netalitica,
 https://pakobserver.net/,NEWS,News Media,2019-08-02,Netalitica,Pakistani News website
-https://slate.com/,NEWS,News Media,2019-08-02,Netalitica,Was blocked due to coverage of PTM
 https://www.newsone.tv/,NEWS,News Media,2019-08-02,Netalitica,News website
 https://nayadaur.tv/,NEWS,News Media,2019-08-02,Netalitica,News website
 https://www.ibctamil.com/,NEWS,News Media,2019-08-02,Netalitica,Tamil News Website


### PR DESCRIPTION
As slate.com is an internationally relevant media website (which may be blocked in more countries, beyond Pakistan), I have removed this site from the PK test list and opened a separate PR to add it to the global test list: https://github.com/citizenlab/test-lists/pull/556

Merging this PR is a prerequisite to merging #556. 