### PR TITLE
Coronavirus update to VE list

### DIFF
--- a/lists/ve.csv
+++ b/lists/ve.csv
@@ -291,3 +291,6 @@ http://zonablackberry.com.ve/,HACK,Hacking Tools,2018-04-10,OONI,
 https://venezuelaaidlive.com/,POLR,Political Criticism,2019-02-28,OONI,Reportedly blocked
 https://evtvmiami.com/,NEWS,News Media,2019-02-28,OONI,Reportedly blocked
 https://www.eltiempo.com/,NEWS,News Media,2019-02-28,OONI,Reportedly blocked
+http://coronavirusvenezuela.info/,PUBH,Public Health,2020-03-19,OONI,Coronavirus information portal reportedly blocked
+https://pvenezuela.com/coronavirus/,PUBH,Public Health,2020-03-19,OONI,Redirect from coronavirusvenezuela.info
+https://presidenciave.com/,POLR,Political Criticism,2020-03-19,OONI,Reportedly blocked


### PR DESCRIPTION
This PR includes the 3 sites that are now reportedly blocked in Venezuela: https://vesinfiltro.com/noticias/bloqueado_portal_coronavirus_AN

Two of these blocked sites are information portals on the coronavirus pandemic.