### PR TITLE
Removed Briar from EG test list

### DIFF
--- a/lists/eg.csv
+++ b/lists/eg.csv
@@ -870,7 +870,6 @@ https://jeem.me/,XED,Sex Education,2018-07-31,OONI,Reportedly blocked
 http://coverme.ws/,COMT,Communication Tools,2019-10-05,Mo,
 http://cyberdust.com/,COMT,Communication Tools,2019-10-05,Mo,
 https://about.riot.im/,COMT,Communication Tools,2019-10-05,Mo,
-https://briarproject.org/,COMT,Communication Tools,2019-10-05,Mo,
 https://bridgefy.me/,COMT,Communication Tools,2019-10-05,Mo,
 https://groupme.com/,COMT,Communication Tools,2019-10-05,Mo,
 https://jami.net/,COMT,Communication Tools,2019-10-05,Mo,


### PR DESCRIPTION
I have removed briarproject.org from the EG test list so that it can be included in the Global test list instead (since we don't support duplicate URLs between the global and country-specific test lists). 

By merging this PR, we are unblocking https://github.com/citizenlab/test-lists/pull/589.