### PR TITLE
EG: +2 News sites reported to be blocked for sharing COVID disinfo

### DIFF
--- a/lists/eg.csv
+++ b/lists/eg.csv
@@ -887,3 +887,5 @@ https://www.bedayaa.org/,LGBT,LGBT,2020-01-20,MoEltaher,
 https://www.theaproject.org/,LGBT,LGBT,2020-01-20,MoEltaher,
 https://www.abaadmena.org/,LGBT,LGBT,2020-01-20,MoEltaher,
 https://kohljournal.press/,LGBT,LGBT,2020-01-20,MoEltaher,
+https://m.gomhuriaonline.com/,NEWS,News Media,2020-04-16,citizenlab,Reportedly blocked for sharing COVID 19 disinformation
+https://hunaaden.com/,NEWS,News Media,2020-04-16,citizenlab,Reportedly blocked for sharing COVID 19 disinformation


### PR DESCRIPTION
These two sites were reported to be ordered blocked in Egypt for sharing COVID-19 related disinformation.