### PR TITLE
Update dz.csv

### DIFF
--- a/lists/dz.csv
+++ b/lists/dz.csv
@@ -137,3 +137,4 @@ http://www.makabylie.org/,MILX,Terrorism and Militants,2019-09-26,OONI,
 http://www.pfln.dz/,POLR,Political Criticism,2019-09-26,OONI,
 https://maghrebemergent.info/,NEWS,News Media,2020-04-11,AkramBa,Reportedly blocked by TELECOM ALGERIA (AS36947)
 https://www.radiom.info/,NEWS,News Media,2020-04-11,AkramBa,Reportedly blocked by TELECOM ALGERIA (AS36947)
+https://www.inter-lignes.com/,NEWS,News Media,2020-04-19,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)


### PR DESCRIPTION
Adding inter-lignes.com blocked in Algeria.
Source : https://www.lemonde.fr/afrique/article/2020/04/20/en-algerie-les-autorites-censurent-un-troisieme-media-en-ligne_6037165_3212.html