### PR TITLE
Update dz.csv

### DIFF
--- a/lists/dz.csv
+++ b/lists/dz.csv
@@ -138,3 +138,4 @@ http://www.pfln.dz/,POLR,Political Criticism,2019-09-26,OONI,
 https://maghrebemergent.info/,NEWS,News Media,2020-04-11,AkramBa,Reportedly blocked by TELECOM ALGERIA (AS36947)
 https://www.radiom.info/,NEWS,News Media,2020-04-11,AkramBa,Reportedly blocked by TELECOM ALGERIA (AS36947)
 https://www.inter-lignes.com/,NEWS,News Media,2020-04-19,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)
+https://www.dzvid.com/,NEWS,News Media,2020-04-24,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)


### PR DESCRIPTION
Adding dzvid.com website reportedly blocked for internet users in Algeria.
Source article : https://www.dzvid.com/2020/04/24/le-site-dzvid-censure-en-algerie/