### PR TITLE
add ocsp.apple.com

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1401,3 +1401,4 @@ https://www.freepik.com/,MMED,Media sharing,2020-04-01,OONI,URL shared by commun
 https://www.f-list.net/,GAME,Gaming,2020-04-01,OONI,URL shared by community member
 https://www.1800respect.org.au/languages/,XED,Sex Education,2020-04-01,OONI,URL shared by community member
 https://www.sbs.com.au/language/coronavirus?cid=infocus,NEWS,News Media,2020-04-01,OONI,URL shared by community member
+http://ocsp.apple.com/ocsp04-aaica02/ME4wTKADAgEAMEUwQzBBMAkGBSsOAwIaBQAEFNqvF+Za6oA4ceFRLsAWwEInjUhJBBQx6napI3Sl39T97qDBpp7GEQ4R7AIIUP1IOZZ86ns=,HACK,Hacking Tools,2020-05-07,Chelchela,it seems to be blocked in some country


### PR DESCRIPTION
Used for the certificate validation in iOS, tvOS, and macOS
https://support.apple.com/en-us/HT210060

https://twitter.com/search?q=ocsp.apple.com%20127.0.0.1&src=typed_query
It is not yet clear why users do this. :man_shrugging: