### PR TITLE
Added 3 News Media sources to br.csv

### DIFF
--- a/lists/br.csv
+++ b/lists/br.csv
@@ -852,9 +852,7 @@ http://terceirotempo.bol.uol.com.br/,CULTR,Culture,2016-06-08,OONI,Blog about sp
 http://terezacs.blogspot.com/,POLR,Political Criticism,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Blogs de direita (Mapeamento Artigo 19)
 http://terezopolis.go.gov.br/,GOVT,Government,2017-08-30,Artigo 19 + CryptoRave + Coding Rights,"Portais dos municípios analisados pela Escala Brasil Transparente (1ª e 2ª edição), http://relatorios.cgu.gov.br/Visualizador.aspx?id_relatorio=1802"
 http://thaumaturgo.ac.gov.br/site01/index.php,GOVT,Government,2017-08-30,Artigo 19 + CryptoRave + Coding Rights,"Portais dos municípios analisados pela Escala Brasil Transparente (1ª e 2ª edição), http://relatorios.cgu.gov.br/Visualizador.aspx?id_relatorio=1196"
-https://theintercept.com/,NEWS,News Media,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Jornalismo independente (Mapeamento Artigo 19)
 https://theintercept.com/2016/05/23/new-political-earthquake-in-brazil-is-it-now-time-for-media-outlets-to-call-this-a-coup/,POLR,Political Criticism,2016-06-10,OONI,
-https://theintercept.com/brasil/,NEWS,News Media,2020-05-17,nunesgh,
 http://thepassiranews.blogspot.com/,POLR,Political Criticism,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Blogs de direita (Mapeamento Artigo 19)
 http://thepatternlibrary.com/,MMED,Media sharing,2017-08-30,Artigo 19 + CryptoRave + Coding Rights,"Direitos autorais (banco de imagens), http://marketingdeconteudo.com/melhores-bancos-de-imagens-gratuitos/"
 http://thestocks.im/,MMED,Media sharing,2017-08-30,Artigo 19 + CryptoRave + Coding Rights,"Direitos autorais (banco de imagens), http://marketingdeconteudo.com/melhores-bancos-de-imagens-gratuitos/"

--- a/lists/br.csv
+++ b/lists/br.csv
@@ -281,6 +281,7 @@ http://dompedro.ma.gov.br/,GOVT,Government,2017-08-30,Artigo 19 + CryptoRave + C
 http://doutorcamargo.pr.gov.br/index.php?sessao=4851b5774f1348,GOVT,Government,2017-08-30,Artigo 19 + CryptoRave + Coding Rights,"Portais dos municípios analisados pela Escala Brasil Transparente (1ª e 2ª edição), http://relatorios.cgu.gov.br/Visualizador.aspx?id_relatorio=871"
 http://dwightlongenecker.com/buy-cytotec-online/,XED,Sex Education,2017-08-30,Artigo 19 + CryptoRave + Coding Rights,Dicas de como fazer aborto
 http://eagora-dil.blogspot.com/,POLR,Political Criticism,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Blogueiros listados no barão de itararé (Mapeamento Artigo 19)
+https://economia.uol.com.br/,NEWS,News Media,2020-05-17,nunesgh,
 http://economiasolidariaeagroenergiaparana.blogspot.com.br/,POLR,Political Criticism,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Blogueiros listados no barão de itararé (Mapeamento Artigo 19)
 http://edsonmoreira.blogspot.com/,POLR,Political Criticism,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Blogs de direita (Mapeamento Artigo 19)
 http://eduardorecchi.blogspot.com/,POLR,Political Criticism,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Blogs de direita (Mapeamento Artigo 19)

--- a/lists/br.csv
+++ b/lists/br.csv
@@ -854,6 +854,7 @@ http://terezopolis.go.gov.br/,GOVT,Government,2017-08-30,Artigo 19 + CryptoRave 
 http://thaumaturgo.ac.gov.br/site01/index.php,GOVT,Government,2017-08-30,Artigo 19 + CryptoRave + Coding Rights,"Portais dos municípios analisados pela Escala Brasil Transparente (1ª e 2ª edição), http://relatorios.cgu.gov.br/Visualizador.aspx?id_relatorio=1196"
 https://theintercept.com/,NEWS,News Media,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Jornalismo independente (Mapeamento Artigo 19)
 https://theintercept.com/2016/05/23/new-political-earthquake-in-brazil-is-it-now-time-for-media-outlets-to-call-this-a-coup/,POLR,Political Criticism,2016-06-10,OONI,
+https://theintercept.com/brasil/,NEWS,News Media,2020-05-17,nunesgh,
 http://thepassiranews.blogspot.com/,POLR,Political Criticism,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Blogs de direita (Mapeamento Artigo 19)
 http://thepatternlibrary.com/,MMED,Media sharing,2017-08-30,Artigo 19 + CryptoRave + Coding Rights,"Direitos autorais (banco de imagens), http://marketingdeconteudo.com/melhores-bancos-de-imagens-gratuitos/"
 http://thestocks.im/,MMED,Media sharing,2017-08-30,Artigo 19 + CryptoRave + Coding Rights,"Direitos autorais (banco de imagens), http://marketingdeconteudo.com/melhores-bancos-de-imagens-gratuitos/"

--- a/lists/br.csv
+++ b/lists/br.csv
@@ -579,6 +579,7 @@ http://nos.twnsnd.co/,MMED,Media sharing,2017-08-30,Artigo 19 + CryptoRave + Cod
 http://nosmulheresdaperiferia.com.br/,NEWS,News Media,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Jornalismo independente (Mapeamento Artigo 19)
 http://nossacarasp.blogspot.com/,POLR,Political Criticism,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Blogueiros listados no barão de itararé (Mapeamento Artigo 19)
 "http://noticias.terra.com.br/brasil/em-que-pe-esta-o-pedido-de-impeachment-contra-michel-temer,a633a296c378f9ee874f331246e45231h6svj3mt.html",POLR,Political Criticism,2016-06-10,OONI,
+https://noticias.uol.com.br/,NEWS,News Media,2020-05-17,nunesgh,
 http://noticias.uol.com.br/ultimas-noticias/agencia-estado/2016/05/22/manifestantes-contra-temer-se-reunem-no-centro-do-rio.htm,POLR,Political Criticism,2016-06-10,OONI,
 http://noticiasemtransito.blogspot.com.br/,POLR,Political Criticism,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Blogueiros listados no barão de itararé (Mapeamento Artigo 19)
 http://novapalmeira.pb.gov.br/,GOVT,Government,2017-08-30,Artigo 19 + CryptoRave + Coding Rights,"Portais dos municípios analisados pela Escala Brasil Transparente (1ª e 2ª edição), http://relatorios.cgu.gov.br/Visualizador.aspx?id_relatorio=1314"

--- a/lists/global.csv
+++ b/lists/global.csv
@@ -261,6 +261,7 @@ http://technorati.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab
 http://teenadvice.about.com/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://telecomix.org/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://thehackernews.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+https://theintercept.com/,NEWS,News Media,2017-08-28,Artigo 19 + CryptoRave + Coding Rights,Jornalismo independente (Mapeamento Artigo 19)
 http://thenationalcampaign.org/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://thepiratebay.org/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://thepiratebay.se/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Hi,

It is my first contribution to Citizen Lab's test lists. I have added three News Media sources to the Brazilian file, namely:

- [economia.uol.com.br](https://economia.uol.com.br)
- [noticias.uol.com.br](https://noticias.uol.com.br)
- [theintercept.com/brasil/](https://theintercept.com/brasil/)

The first two are the economy-related website and the general-news website from major local UOL portal. The third one is the pt-br branch of The Intercept, run in Brazil by Glenn Greenwald.

Based on the news coverage by those websites and recent statements from Brazil's president and members of his family, I think those three websites should be added to the br.csv file.

Thank you.