### PR TITLE
Add Write.as

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1401,3 +1401,4 @@ https://www.freepik.com/,MMED,Media sharing,2020-04-01,OONI,URL shared by commun
 https://www.f-list.net/,GAME,Gaming,2020-04-01,OONI,URL shared by community member
 https://www.1800respect.org.au/languages/,XED,Sex Education,2020-04-01,OONI,URL shared by community member
 https://www.sbs.com.au/language/coronavirus?cid=infocus,NEWS,News Media,2020-04-01,OONI,URL shared by community member
+https://write.as/,HOST,Hosting and Blogging Platforms,2020-05-18,thebaer,Getting reports of domain issues in Indonesia


### PR DESCRIPTION
We run a privacy-centric blogging platform called [Write.as](https://write.as) that's used all over the world. Considering our mission to give writers anonymity, and some odd DNS errors recently [reported](https://writing.exchange/@matt/104195516669277207) by users in Indonesia, it looks like we're seeing some kind of censorship happening there. It would be great to test for that.