### PR TITLE
Added Let's Encrypt to global test list

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1402,5 +1402,5 @@ https://www.f-list.net/,GAME,Gaming,2020-04-01,OONI,URL shared by community memb
 https://www.1800respect.org.au/languages/,XED,Sex Education,2020-04-01,OONI,URL shared by community member
 https://www.sbs.com.au/language/coronavirus?cid=infocus,NEWS,News Media,2020-04-01,OONI,URL shared by community member
 https://www.gutenberg.org/,CULTR,Culture,2020-05-18,eshellman,Public domain site targeted by copyright extremists
-https://letsencrypt.org/,ANON,Anonymization and circumvention tools,2020-05-20,OONI,
-http://ocsp.int-x3.letsencrypt.org/,ANON,Anonymization and circumvention tools,2020-05-20,OONI,
+https://letsencrypt.org/,HOST,Hosting and Blogging Platforms,2020-05-20,OONI,
+http://ocsp.int-x3.letsencrypt.org/,HOST,Hosting and Blogging Platforms,2020-05-20,OONI,

--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1402,3 +1402,5 @@ https://www.f-list.net/,GAME,Gaming,2020-04-01,OONI,URL shared by community memb
 https://www.1800respect.org.au/languages/,XED,Sex Education,2020-04-01,OONI,URL shared by community member
 https://www.sbs.com.au/language/coronavirus?cid=infocus,NEWS,News Media,2020-04-01,OONI,URL shared by community member
 https://www.gutenberg.org/,CULTR,Culture,2020-05-18,eshellman,Public domain site targeted by copyright extremists
+https://letsencrypt.org/,ANON,Anonymization and circumvention tools,2020-05-20,OONI,
+http://ocsp.int-x3.letsencrypt.org/,ANON,Anonymization and circumvention tools,2020-05-20,OONI,


### PR DESCRIPTION
This PR adds letsencrypt.org to the global test list, as well http://ocsp.int-x3.letsencrypt.org/ which is reportedly blocked in China, but probably worth testing globally.