### PR TITLE
Update dz.csv

### DIFF
--- a/lists/dz.csv
+++ b/lists/dz.csv
@@ -139,3 +139,5 @@ https://maghrebemergent.info/,NEWS,News Media,2020-04-11,AkramBa,Reportedly bloc
 https://www.radiom.info/,NEWS,News Media,2020-04-11,AkramBa,Reportedly blocked by TELECOM ALGERIA (AS36947)
 https://www.inter-lignes.com/,NEWS,News Media,2020-04-19,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)
 https://www.dzvid.com/,NEWS,News Media,2020-04-24,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)
+https://www.lavantgarde-algerie.com/,NEWS,News Media,2020-05-22,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)
+https://www.lematindalgerie.com/,NEWS,News Media,2020-05-22,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)

--- a/lists/dz.csv
+++ b/lists/dz.csv
@@ -140,4 +140,3 @@ https://www.radiom.info/,NEWS,News Media,2020-04-11,AkramBa,Reportedly blocked b
 https://www.inter-lignes.com/,NEWS,News Media,2020-04-19,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)
 https://www.dzvid.com/,NEWS,News Media,2020-04-24,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)
 https://www.lavantgarde-algerie.com/,NEWS,News Media,2020-05-22,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)
-https://www.lematindalgerie.com/,NEWS,News Media,2020-05-22,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)


### PR DESCRIPTION
Adding two 2 algerian media websites  :
* L'avant Garde
* Le Matin d'Algérie

Reportedly censored to algerian internet users.

* Source : https://www.lorientlejour.com/article/1218208/un-nouveau-site-dinformation-bloque-en-algerie.html
* Source : https://rsf.org/fr/actualites/algerie-quand-les-autorites-sacharnent-sur-les-medias-au-lieu-de-lutter-contre-la-pandemie