### PR TITLE
added grindr rest api endpoint to global

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -632,6 +632,7 @@ http://www.granma.cu/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2
 http://www.greennet.org.uk/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.greenpeace.org/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.grindr.com/,LGBT,LGBT,2016-07-22,OONI,Updated by OONI on 2017-02-14
+https://grindr.mobi/,LGBT,LGBT,2020-07-22,citizenlab,main rest api endpoint used by app
 https://www.groupon.com/,COMM,E-commerce,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.guerrillagirls.com/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.guildwars.com/,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Even though we have grindr.com on the global list, the app itself uses this domain (grindr.mobi) as its main REST endpoint.  I ran some pcaps to determine this (based on the Android version) Also decompiling the classes.dex and looking at buildConfig.xml specifies this:

```
.field public static final REST_SERVICE_ENDPOINT:Ljava/lang/String; = "https://grindr.mobi/"
```

The URL should show a 404 for a simple visit here are some sample endpoints used by the app:

* https://grindr.mobi/v4/me/gdpr-data/status
* https://grindr.mobi/v3.1/chat/backup
* https://grindr.mobi/v4/videos/expiring/status

Also when I blocked this endpoint in my lab environment the app functionality breaks (can't update feed, can't sign up, etc)  So this might be a good way to test website accessibility vs app accessibility.