### PR TITLE
Added new URLs to Poland list.

### DIFF
--- a/lists/pl.csv
+++ b/lists/pl.csv
@@ -107,3 +107,24 @@ https://pl.wikiquote.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wi
 https://pl.wikibooks.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://en.wiktionary.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://www.gov.pl/web/zdrowie/co-musisz-wiedziec-o-koronawirusie,PUBH,Public Health,2020-04-01,citizenlab,coronavirus
+https://stopbzdurom.pl/,LGBT,LGBT,2020-08-17,citizenlab,LGBT activist group
+https://lgbtfreezones.pl/,LGBT,LGBT,2020-08-17,citizenlab,Project that maps LGBT-free zones in the country
+https://atlasnienawisci.pl/,LGBT,LGBT,2020-08-17,citizenlab,Project that maps places that discriminate against LGBT folks in the country
+https://www.prideshop.pl/,LGBT,LGBT,2020-08-17,citizenlab,Store for rainbow flag related merchandise
+https://www.wprost.pl/,NEWS,News Media,2020-08-17,citizenlab,Weekly newsmagazine
+https://www.rmf24.pl/,NEWS,News Media,2020-08-17,citizenlab,Radio station
+https://www.tokfm.pl/,NEWS,News Media,2020-08-17,citizenlab,Radio station
+https://www.polsatnews.pl/,NEWS,News Media,2020-08-17,citizenlab,TV station
+https://www.newsweek.pl/,NEWS,News Media,2020-08-17,citizenlab,Magazine
+https://www.fakt.pl/,NEWS,News Media,2020-08-17,citizenlab,Tabloid
+https://www.se.pl/,NEWS,News Media,2020-08-17,citizenlab,Tabloid
+https://dziennikpolski24.pl/,NEWS,News Media,2020-08-17,citizenlab,Newspaper
+https://polskatimes.pl/,NEWS,News Media,2020-08-17,citizenlab,Newspaper
+http://ppspl.eu/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Polish Socialist
+https://konfederacja.net/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Konfederacja
+https://lewica2019.pl/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Lewica Razem
+https://sld.org.pl/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Sojusz Lewicy Demokratycznej
+http://pis.org.pl/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Law and Justice
+https://www.psl.pl/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Polskie Stronnictwo Ludowe
+https://platforma.org/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Platforma Obywatelska
+https://ruchnarodowy.net/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Ruch Narodowy


### PR DESCRIPTION
Polish list hasn't been updated in a while so I added some URLs related to recent events.  There are three categories of URLs here:

* LGBT - in light of recent coverage of [LGBT related issues](https://notesfrompoland.com/2020/08/06/lgbt-activists-detained-and-charged-in-poland-for-putting-rainbow-flags-on-statues/) I added a major activist group that is emerging Stop Bzdurom, as well as some efforts at mapping the so called LGBT-free zones and places that discriminate against LGBT folks.

* News Media - there was a lot of missing news media sources since the list hasn't been updated in so long.  I added some major radio stations, tabloids, newspapers, weeklies, etc.

* Political Parties - I added the official sites of some of the major current political parties as well as those that are are strongly on one side of the spectrum.