### PR TITLE
Added blocked sites to CN test list

### DIFF
--- a/lists/cn.csv
+++ b/lists/cn.csv
@@ -563,3 +563,7 @@ http://citizenlab.org/,HUMR,Human Rights Issues,2020-04-03,tomacat,
 https://www.project-syndicate.org/,POLR,Political Criticism,2020-04-03,tomacat,
 https://www.ustream.tv/,MMED,Media sharing,2020-04-03,tomacat,
 http://mail-archive.com/,GRP,Social Networking,2020-04-03,tomacat,
+https://www.cecc.gov/,GOVT,Government,2020-11-04,Phong - OTF fellow,Reportedly blocked
+https://www.uscirf.gov/,GOVT,Government,2020-11-04,Phong - OTF fellow,Reportedly blocked
+https://www.govtrack.us/,GOVT,Government,2020-11-04,Phong - OTF fellow,Reportedly blocked
+https://thewire.in/,NEWS,News Media,2020-11-04,Phong - OTF fellow,Reportedly blocked


### PR DESCRIPTION
This PR includes updates to the CN test list based on URLs shared by OTF Fellow, Phong. These URLs seem to be blocked in CN.