### PR TITLE
Update dz.csv

### DIFF
--- a/lists/dz.csv
+++ b/lists/dz.csv
@@ -140,3 +140,9 @@ https://www.radiom.info/,NEWS,News Media,2020-04-11,AkramBa,Reportedly blocked b
 https://www.inter-lignes.com/,NEWS,News Media,2020-04-19,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)
 https://www.dzvid.com/,NEWS,News Media,2020-04-24,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)
 https://www.lavantgarde-algerie.com/,NEWS,News Media,2020-05-22,Anonymous,Reportedly blocked by TELECOM ALGERIA (AS36947)
+https://www.amnestyalgerie.org/,HUMR,Human Rights Issues,2020-11-23,Anonymous,
+https://algeriepartplus.com/,NEWS,News Media,2020-11-23,Anonymous,Algerian news website 
+https://tamurt.info/fr/,NEWS,News Media,2020-11-23,Anonymous,News website for the Kabyle minority in Algeria blocked in 2017
+https://marevuedepressedz.com/,NEWS,News Media,2020-11-23,Anonymous,News aggregator reportedly blocked in Algeria
+https://maroc-diplomatique.net/,NEWS,News Media,2020-11-23,Anonymous,Moroccan news media that could be blocked during tensions between the two countries
+https://telquel.ma/,NEWS,News Media,2020-11-23,Anonymous,Moroccan news media that could be blocked during tensions between the two countries


### PR DESCRIPTION
Added 6 websites which accessibility can be relevant to check in Algeria:
- 2 of them are Moroccan news websites that are reportedly blocked when the tensions rise between the two countries, 
- 1 is Amazigh / Kabyle news website
- 2 are Algerian news websites which are reportedly blocked
- 1 website of Amnesty Algeria, the Algerian section of Amnesty International which saw disruption in its accessibility from Algeria in the previous months and is now behind a Cloudflare service