### PR TITLE
add googleweblight to global.csv

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1447,3 +1447,4 @@ https://family.cloudflare-dns.com/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxl
 https://download.i2p2.de/,ANON,Anonymization and circumvention tools,2020-10-16,Chelchela,
 https://i2pforum.net/,ANON,Anonymization and circumvention tools,2020-10-16,Chelchela,Also GRP-Social Networking
 https://muwire.com/,FILE,File-sharing,2020-10-16,Chelchela,New address for limewire.com -- Easy anonymous file sharing using I2P technology
+https://googleweblight.com/i?u=https%3A%2F%2Fexample.com%2F,ANON,Anonymization and circumvention tools,2020-11-30,Chelchela,


### PR DESCRIPTION
Used in Google Go.
https://developers.google.com/search/docs/advanced/mobile/web-light?hl=en#see-the-web-light-version-of-a-web-page

Blocked in Iran. ( AS197207 is also Iran)
https://explorer.ooni.org/search?until=2020-12-01&since=2020-11-01&domain=googleweblight.com