### PR TITLE
Added ESPIV to global test list

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1449,3 +1449,5 @@ https://i2pforum.net/,ANON,Anonymization and circumvention tools,2020-10-16,Chel
 https://muwire.com/,FILE,File-sharing,2020-10-16,Chelchela,New address for limewire.com -- Easy anonymous file sharing using I2P technology
 https://googleweblight.com/i?u=https%3A%2F%2Fexample.com%2F,ANON,Anonymization and circumvention tools,2020-11-30,Chelchela,
 https://makeamazonpay.com/,POLR,Political Criticism,2020-11-30,OONI,
+https://espivblogs.net/,HOST,Hosting and Blogging Platforms,2020-12-17,OONI,Run by an autonomous collective and often used by activists
+https://espiv.net/,COMT,Communication Tools,2020-12-17,OONI,Run by an autonomous collective and often used by activists


### PR DESCRIPTION
I updated the global test list to add 2 espiv domains. ESPIV provide emails, mailing lists, blogging platforms, and forums -- all of which are run by an autonomous collective and these services are often used by human rights activists. 

Part of the motivation to add this now to the global test list is also the fact that it's being reported that ESPIV services may be blocked in Spain and Chile, and it may be interesting to test them globally on an ongoing basis.