### PR TITLE
Adding potentially blocked china covid urls

### DIFF
--- a/lists/cn.csv
+++ b/lists/cn.csv
@@ -567,3 +567,9 @@ https://www.cecc.gov/,GOVT,Government,2020-11-04,Phong - OTF fellow,Reportedly b
 https://www.uscirf.gov/,GOVT,Government,2020-11-04,Phong - OTF fellow,Reportedly blocked
 https://www.govtrack.us/,GOVT,Government,2020-11-04,Phong - OTF fellow,Reportedly blocked
 https://thewire.in/,NEWS,News Media,2020-11-04,Phong - OTF fellow,Reportedly blocked
+https://ccpcoronavirus.com/,PUBH,Public Health,2021-01-04,Phong - OTF fellow,Coronavirus related and potential DNS block
+https://covid-19truth.info/,PUBH,Public Health,2021-01-04,Phong - OTF fellow,Coronavirus related and potential DNS block
+http://covid19song.info/,PUBH,Public Health,2021-01-04,Phong - OTF fellow,Coronavirus related and potential DNS block
+https://covidcon.org/,PUBH,Public Health,2021-01-04,Phong - OTF fellow,Coronavirus related and potential DNS block
+https://www.covid19classaction.it/,PUBH,Public Health,2021-01-04,Phong - OTF fellow,Coronavirus related and potential DNS block. Italian language site.
+http://covidhaber.net/,PUBH,Public Health,2021-01-04,Phong - OTF fellow,Coronavirus related and potential DNS block. Turkish language site.


### PR DESCRIPTION
I am proxying this update for Phong (OTF) but his work seems to indicate these six domains are being DNS poisioned within China.  Hoping to see the breadth of this behaviour with this update.

Cheers,
Jakub