### PR TITLE
Update Hong Kong list to account for developments.

### DIFF
--- a/lists/hk.csv
+++ b/lists/hk.csv
@@ -595,5 +595,6 @@ https://www.bpahk.org/,POLR,Political Criticism,2020-07-21,Netalitica,
 https://www.facebook.com/hongkongpda/,POLR,Political Criticism,2020-07-21,Netalitica,keep for control purposes
 https://www.facebook.com/HongkongSeparatism/,POLR,Political Criticism,2020-07-21,Netalitica,keep for control purposes
 https://www.scmp.com/news/hong-kong/law-and-crime/article/3096679/hong-kong-national-security-law-media-mogul-jimmy-lai,NEWS,News Media,2020-08-10,Netalitica,article on harassing local news media
-https://hkchronicles.com/,NEWS,News Media,2021-01-07,citizenlab,Reportedly blocked news site
-https://hkleaks.info/,POLR,Political Criticism,2021-01-07,OONI,Reportedly blocked
+https://hkchronicles.com/,POLR,Political Criticism,2021-01-07,citizenlab,Reportedly blocked site
+https://hkleaks.info/,POLR,Political Criticism,2021-01-07,OONI,Reportedly blocked site
+https://blockedbyhk.com/,POLR,Political Criticism,2021-01-19,Community member,Additional domain for hkchronicles.com


### PR DESCRIPTION
- hkleaks.info and hkchronicles.com are both the same site. They're closer to political criticism than they are to a news source.
- Four days ago the administrator of the site created a *third* domain pointing to the same site, blockedbyhk.com.
- The first two domains were both included in the first-known instance of using the NSL to block websites in Hong Kong.
- The third domain, blockedbyhk.com, as of the date of this PR remains unblocked.