### PR TITLE
Add Namecoin.org

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1460,3 +1460,4 @@ https://lh4.ggpht.com/_PvLDsC2pRvk/ShwiscZujVI/AAAAAAAAFIQ/4q-TYiQ13-k/s512/DSC0
 https://yt3.ggpht.com/a-/AOh14GhGCI1dxtHOY_TDQfmxDBK_S7CHTPJ3U6zOUw=s480-c-k-c0x00ffffff-no-rj-mo,HOST,Hosting and Blogging Platforms,2021-01-11,Chelchela,
 https://yt4.ggpht.com/a-/AOh14GhOiUxI-RcMC-Vfl2i15v3xewMr8bt2yNXTfw=s480-c-k-c0x00ffffff-no-rj-mo,HOST,Hosting and Blogging Platforms,2021-01-11,Chelchela,
 https://i.ytimg.com/vi/JBRf3nEqfZ8/hq720.jpg,HOST,Hosting and Blogging Platforms,2021-01-11,Chelchela,
+https://www.namecoin.org/,ANON,Anonymization and circumvention tools,2021-02-04,Namecoin,Blockchain-based DNS-like naming system; reported to be blocked in Belarus in January 2021


### PR DESCRIPTION
Seems on-topic given that other censorship-resistant suTLD's such as Tor, DNS providers such as OpenDNS, and other blockchain projects such as Bitcoin are on the list.  Also seems sufficiently non-redundant given that I don't see any other decentralized DNS-like naming systems on the list.  I got a user report alleging that it was blocked in Belarus in January 2021 (I haven't been able to verify the accuracy of that report).

I initially reached out on IRC; @agrabeli recommended that I open a PR here.