### PR TITLE
Updated NG test list

### DIFF
--- a/lists/ng.csv
+++ b/lists/ng.csv
@@ -322,3 +322,5 @@ http://www.theequalityhub.com/,LGBT,LGBT,2020-01-29,OONI partner,
 https://feministcoalition2020.com/,HUMR,Human Rights Issues,2020-11-30,OONI,Reportedly blocked
 https://endsars.com/,HUMR,Human Rights Issues,2020-12-15,OONI,Reportedly blocked
 https://radioisiaq.com/,POLR,Political Criticism,2020-12-15,OONI,Reportedly blocked
+https://www.peoplesgazette.com/,NEWS,News Media,2021-02-05,OONI,Reportedly blocked
+https://www.gazettengr.com/,NEWS,News Media,2021-02-05,OONI,Reportedly blocked


### PR DESCRIPTION
I've updated the NG test list to include a media website that's reportedly blocked.

For reference:

https://twitter.com/GazetteNGR/status/1354446025000415246
https://guardian.ng/news/clampdown-on-peoples-gazette-as-telcos-block-access-to-news-website/
http://saharareporters.com/2021/01/28/nigerian-government-blocks-peoples-gazette-website-over-critical-media-reports