### PR TITLE
Add tests for Signal Messenger

### DIFF
--- a/lists/mm.csv
+++ b/lists/mm.csv
@@ -856,3 +856,8 @@ https://www.myanmarpress.com/,NEWS,News Media,2020-03-26,Kyaw,Blocklist
 https://www.justiceformyanmar.org/,HUMR,Human Rights Issues,2020-08-31,OONI,Reportedly blocked
 https://opendevelopmentmyanmar.net/,HUMR,Human Rights Issues,2021-02-15,arky,Myanmar Open Data Portal
 https://opendevelopmentmekong.net/,HUMR,Human Rights Issues,2021-02-15,arky,Open Data Portal for Lower Mekong countries
+https://textsecure-service.whispersystems.org/,COMT,Communication Tools,2021-02-22,arky,Tests for Signal Messenger
+https://storage.signal.org/,COMT,Communication Tools,2021-02-22,arky,Tests for Signal Messenger
+https://api.directory.signal.org/,COMT,Communication Tools,2021-02-22,arky,Tests for Signal Messenger
+https://cdn.signal.org/,COMT,Communication Tools,2021-02-22,arky,Tests for Signal Messenger
+https://cdn2.signal.org/,COMT,Communication Tools,2021-02-22,arky,Tests for Signal Messenger


### PR DESCRIPTION
Added tests for Signal messenger as stop-gap measure until the [signal messenger tests](https://github.com/ooni/probe-cli/pull/230/files#diff-ed1b4f0013a12402e0f5ced63481629b1606b49c75d2e4a91d7081df31ebafa4R112) are implemented in the new release.