### PR TITLE
Removed NordVPN from EG list

### DIFF
--- a/lists/eg.csv
+++ b/lists/eg.csv
@@ -838,7 +838,6 @@ https://www.le-vpn.com/,ANON,Anonymization and circumvention tools,2017-08-30,Ma
 http://www.libertyvpn.net/,ANON,Anonymization and circumvention tools,2017-08-30,Masaar,
 https://www.my-proxy.com/,ANON,Anonymization and circumvention tools,2017-08-30,Masaar,
 http://www.nanoproxy.de/,ANON,Anonymization and circumvention tools,2017-08-30,Masaar,
-https://nordvpn.com/,ANON,Anonymization and circumvention tools,2017-08-30,Masaar,
 https://www.overplay.net/,ANON,Anonymization and circumvention tools,2017-08-30,Masaar,
 https://www.perfect-privacy.com/,ANON,Anonymization and circumvention tools,2017-08-30,Masaar,
 https://www.sumrando.com/,ANON,Anonymization and circumvention tools,2017-08-30,Masaar,


### PR DESCRIPTION
NordVPN should be included in the global test list (to get tested globally). To avoid duplication of URLs (and since I'm trying to add it to the global test list: https://github.com/citizenlab/test-lists/pull/734), I am opening this PR to remove it from the EG test list.