### PR TITLE
Add provider to global list

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1444,4 +1444,4 @@ https://speedify.com/,ANON,Anonymization and circumvention tools,2021-03-05,OONI
 https://hola.org/,ANON,Anonymization and circumvention tools,2021-03-05,OONI,Might be blocked in Myanmar but worth testing globally
 https://thunder.free-signal.com/,ANON,Anonymization and circumvention tools,2021-03-05,OONI,Might be blocked in Myanmar but worth testing globally
 https://www.f-secure.com/en/home/products/freedome/,ANON,Anonymization and circumvention tools,2021-03-05,OONI,Might be blocked in Myanmar but worth testing globally
-https://greenhost.net,HOST,Hosting and Blogging Platforms,2021-03-15,Greenhost,
+https://greenhost.net,HOST,Hosting and Blogging Platforms,2021-03-15,Greenhost,Hosting provider focussing on digital rights and privacy

--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1444,3 +1444,4 @@ https://speedify.com/,ANON,Anonymization and circumvention tools,2021-03-05,OONI
 https://hola.org/,ANON,Anonymization and circumvention tools,2021-03-05,OONI,Might be blocked in Myanmar but worth testing globally
 https://thunder.free-signal.com/,ANON,Anonymization and circumvention tools,2021-03-05,OONI,Might be blocked in Myanmar but worth testing globally
 https://www.f-secure.com/en/home/products/freedome/,ANON,Anonymization and circumvention tools,2021-03-05,OONI,Might be blocked in Myanmar but worth testing globally
+https://greenhost.net,HOST,Hosting and Blogging Platforms,2021-03-15,Greenhost,

--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1444,4 +1444,4 @@ https://speedify.com/,ANON,Anonymization and circumvention tools,2021-03-05,OONI
 https://hola.org/,ANON,Anonymization and circumvention tools,2021-03-05,OONI,Might be blocked in Myanmar but worth testing globally
 https://thunder.free-signal.com/,ANON,Anonymization and circumvention tools,2021-03-05,OONI,Might be blocked in Myanmar but worth testing globally
 https://www.f-secure.com/en/home/products/freedome/,ANON,Anonymization and circumvention tools,2021-03-05,OONI,Might be blocked in Myanmar but worth testing globally
-https://greenhost.net,HOST,Hosting and Blogging Platforms,2021-03-15,Greenhost,Hosting provider focussing on digital rights and privacy
+https://greenhost.net/,HOST,Hosting and Blogging Platforms,2021-03-15,Greenhost,Hosting provider focussing on digital rights and privacy


### PR DESCRIPTION
Add Greenhost main site, a provider focussing on digital rights and privacy to the global list