### PR TITLE
Updated MM test list

### DIFF
--- a/lists/mm.csv
+++ b/lists/mm.csv
@@ -825,3 +825,4 @@ https://api.directory.signal.org/,COMT,Communication Tools,2021-02-22,arky,Tests
 https://cdn.signal.org/,COMT,Communication Tools,2021-02-22,arky,Tests for Signal Messenger
 https://cdn2.signal.org/,COMT,Communication Tools,2021-02-22,arky,Tests for Signal Messenger
 https://crphmyanmar.org/,GOVT,Government,2021-03-06,arky,Committe Representing Pyidaungsu Hluttaw
+https://iimm.un.org/,POLR,Political Criticism,2021-03-18,OONI,Reportedly blocked


### PR DESCRIPTION
I'm updating the MM test list to include https://iimm.un.org/ which is reportedly blocked in Myanmar.