### PR TITLE
Remove twilight.ws

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -275,7 +275,6 @@ https://trashy.com/,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OON
 http://triviasecurity.net/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://turbobit.net/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://tvants.uptodown.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://twilight.ws/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://twitpic.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://twitter.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://twitter.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Website is down for more than a year. Domain is parked.