### PR TITLE
Add ipfs.io to BE list

### DIFF
--- a/lists/be.csv
+++ b/lists/be.csv
@@ -5,3 +5,4 @@ https://pl.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wi
 https://fr.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://fr.m.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://pralido.be/,DATE,Online Dating,2020-04-01,OONI,URL shared by community member
+https://ipfs.io/,ANON,Anonymization and circumvention tools,2021-04-01,magma,Reported as blocked in Belgium https://web.archive.org/web/20210401073940/https://discuss.ipfs.io/t/ipfs-blocked-in-belgium/7930

--- a/lists/be.csv
+++ b/lists/be.csv
@@ -5,4 +5,4 @@ https://pl.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wi
 https://fr.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://fr.m.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://pralido.be/,DATE,Online Dating,2020-04-01,OONI,URL shared by community member
-https://ipfs.io/,ANON,Anonymization and circumvention tools,2021-04-01,magma,Reported as blocked in Belgium https://web.archive.org/web/20210401073940/https://discuss.ipfs.io/t/ipfs-blocked-in-belgium/7930
+https://ipfs.io/,FILE,File-sharing,2021-04-01,magma,Reported as blocked in Belgium https://web.archive.org/web/20210401073940/https://discuss.ipfs.io/t/ipfs-blocked-in-belgium/7930


### PR DESCRIPTION
ipfs.io reported as blocked in Belgium
https://web.archive.org/web/20210401073940/https://discuss.ipfs.io/t/ipfs-blocked-in-belgium/7930