### PR TITLE
Remove parked domain www.meaphone.com

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -772,7 +772,6 @@ http://www.match.com/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI o
 http://www.mate1.com/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.matrimony.org/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.maven.co.il/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.meaphone.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.medecinsdumonde.org/,PUBH,Public Health,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.mediafire.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.medicinenet.com/,PUBH,Public Health,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
It's failing globally: https://explorer.ooni.org/search?until=2021-04-07&since=2021-03-07&domain=www.meaphone.com