### PR TITLE
Remove www.sexualhealth.com

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -940,7 +940,6 @@ http://www.sex.com/,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 20
 http://www.sexandu.ca/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.sexandu.ca/fr/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.sexedlibrary.org/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-https://www.sexualhealth.com/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.shinto.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.shroomery.org/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.sida.se/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Probably the domain has a new owner now. It seems that for a year it was entirely down and now it's either redirecting to a porn site or entirely inaccessible:
https://web.archive.org/web/20210901000000*/www.sexualhealth.com
https://explorer.ooni.org/search?until=2021-04-07&since=2021-03-07&domain=www.sexualhealth.com