### PR TITLE
Add CTRL for PL CERT lista ostrzezen

### DIFF
--- a/lists/pl.csv
+++ b/lists/pl.csv
@@ -125,3 +125,6 @@ http://pis.org.pl/,POLR,Political Criticism,2020-08-17,citizenlab,Political part
 https://www.psl.pl/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Polskie Stronnictwo Ludowe
 https://platforma.org/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Platforma Obywatelska
 https://ruchnarodowy.net/,POLR,Political Criticism,2020-08-17,citizenlab,Political party - Ruch Narodowy
+https://sub1.blocked-site-hole-cert.pl/,CTRL,Control content,2021-04-06,unknown,CTRL for https://www.cert.pl/posts/2020/03/ostrzezenia_phishing/
+https://sub2.blocked-site-hole-cert.pl/,CTRL,Control content,2021-04-06,unknown,CTRL for https://www.cert.pl/posts/2020/03/ostrzezenia_phishing/
+https://sub3.blocked-site-hole-cert.pl/,CTRL,Control content,2021-04-06,unknown,CTRL for https://www.cert.pl/posts/2020/03/ostrzezenia_phishing/


### PR DESCRIPTION
Those seem to be control domains used by them. Discovered through own analysis of the list.