### PR TITLE
Remove www.connotea.org

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -454,7 +454,6 @@ http://www.cnn.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 201
 https://www.coinbase.com/,COMM,E-commerce,2018-11-15,blockchain,Initial tracking of cryptocurrencies on 2018-11-15. Cryptocurrency exchange
 http://www.collegehumor.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.concern.net/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.connotea.org/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.convertingtojudaism.com/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.copticchurch.net/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.coquette.com/,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Website is down. Was last seen in 2016: https://web.archive.org/web/20160830114545/http://www.connotea.org/
> Connotea discontinued service on March 12, 2013.