### PR TITLE
Remove international.ohmynews.com

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -139,7 +139,6 @@ https://imp.free.fr/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by O
 https://indymedia.org/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://infidels.org/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://insecure.org/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://international.ohmynews.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://ipi.media/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://isaalmasih.net/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://islamonline.net/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Last content on the website was from 2013, so it's not surprising that it's gone: https://web.archive.org/web/20200721180116/http://international.ohmynews.com/