### PR TITLE
Remove www.arabhra.org

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -364,7 +364,6 @@ http://www.anonymsurfen.com/,ANON,Anonymization and circumvention tools,2014-04-
 https://www.apple.com/,COMM,E-commerce,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.appzplanet.com/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.apt.ch/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.arabhra.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.arabnews.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.arabrenewal.com/,MILX,Terrorism and Militants,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.arabtimes.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Down since 2019: https://web.archive.org/web/20190102003828/http://www.arabhra.org/