### PR TITLE
Remove www.familiesaretalking.org

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -537,7 +537,6 @@ http://www.exmormon.org/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2
 https://www.exploit-db.com/,HACK,Hacking Tools,2016-06-10,OONI,Updated by OONI on 2017-02-14
 http://www.facebook.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.facebook.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.familiesaretalking.org/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.familycareintl.org/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.fark.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.fastmail.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Down since 2017: https://web.archive.org/web/20170907040058/http://www.familiesaretalking.org/