### PR TITLE
Remove www.efindlove.com

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -515,7 +515,6 @@ http://www.ectaco.com/info/software/?atid=2021,COMT,Communication Tools,2014-04-
 https://www.edf.org/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.eea.europa.eu/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.eff.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.efindlove.com/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.efonica.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.eharmony.com/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.eln-voces.com/,MILX,Terrorism and Militants,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Down since 2017: https://web.archive.org/web/20170916084953/http://efindlove.com/. Now parked.