### PR TITLE
Remove translation.langenberg.com

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -266,7 +266,6 @@ http://torah.org/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-
 https://torrentz.eu/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://translate.google.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://translate.reference.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://translation.langenberg.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://translation2.paralink.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://translator.babylon-software.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://transsexual.org/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Domain is parked. Has been down for a long time.