### PR TITLE
Remove www.crackz.ws

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -457,7 +457,6 @@ http://www.copticchurch.net/,REL,Religion,2014-04-15,citizenlab,Updated by OONI 
 http://www.coquette.com/,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.counter-strike.net/,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.cpj.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.crackz.ws/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.crazyshit.com/,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.crisisgroup.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.crs.org/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Parked at least since 2019: https://web.archive.org/web/20190114201444/http://www.crackz.ws/