### PR TITLE
Add sanctioned-suicide.org to it.csv

### DIFF
--- a/lists/it.csv
+++ b/lists/it.csv
@@ -265,3 +265,4 @@ https://it.wikiquote.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wi
 https://it.wiktionary.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://it.m.wikipedia.org/,CULTR,Culture,2019-02-19,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 http://liste.gasbo.it/wws/,COMT,Communication Tools,2020-11-11,OONI,Reportedly blocked in Italy
+https://sanctioned-suicide.org/,PUBH,Public Health,2021-06-07,OONI,Blocked in Italy


### PR DESCRIPTION
Blocked in Italy, see: https://roma.corriere.it/notizie/cronaca/21_giugno_07/roma-istruzioni-ragazzi-il-suicidio-oscurato-sito-internet-7e7911ce-c769-11eb-9c4c-4cf000dece4f.shtml