### PR TITLE
add image and web cache related to search engines

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1460,6 +1460,15 @@ https://blog.mozilla.org/,HACK,Hacking Tools,2021-04-04,Chelchela,
 https://download-installer.cdn.mozilla.net/,HOST,Hosting and Blogging Platforms,2021-04-04,Chelchela,
 https://dl.google.com/robots.txt,HOST,Hosting and Blogging Platforms,2021-04-04,Chelchela,
 https://www.gstatic.com/robots.txt,HOST,Hosting and Blogging Platforms,2021-04-04,Chelchela,
+https://webcache.googleusercontent.com/robots.txt,SRCH,Search Engines,2021-07-03,Chelchela,Google web cache
+https://yandexwebcache.net/robots.txt,SRCH,Search Engines,2021-07-03,Chelchela,Yandex web cache
+https://cc.bingj.com/cache.aspx?q=nothing,SRCH,Search Engines,2021-07-03,Chelchela,Bing web cache
+https://encrypted-tbn0.gstatic.com/robots.txt,SRCH,Search Engines,2021-07-03,Chelchela,Google image thumbnail cache
+https://im0-tub-com.yandex.net/i?id=462f375c96139f1e41d919b44be2d780&n=13&exp=1,SRCH,Search Engines,2021-07-03,Chelchela,Yandex image thumbnail cache
+https://th.bing.com/th/id/OIP.YnpdokcN_OQYn3n41AlqZAHaEe?w=250&h=180&c=7&o=5&pid=1.7,SRCH,Search Engines,2021-07-03,Chelchela,Bing image thumbnail cache
+https://external-content.duckduckgo.com/robots.txt,SRCH,Search Engines,2021-07-03,Chelchela,Duckduckgo image cache
+https://miro.medium.com/robots.txt,HOST,Hosting and Blogging Platforms,2021-07-03,Chelchela,
+https://cdn-client.medium.com/lite/static/js/manifest.ef5f44d2.js,HOST,Hosting and Blogging Platforms,2021-07-03,Chelchela,
 https://www.clubhouseapi.com/,GRP,Social Networking,2021-04-04,Chelchela,
 https://clubhouse.pubnub.com/,GRP,Social Networking,2021-04-04,Chelchela,
 https://brave.com/,HACK,Hacking Tools,2021-06-24,Chelchela,


### PR DESCRIPTION
And add two addresses related to Medium.

(`miro.medium.com` and `external-content.duckduckgo.com` are blocked in Iran.)

[OONI Run](https://run.ooni.io/nettest?tn=web_connectivity&ta=%7B%22urls%22%3A%5B%22https%3A%2F%2Fwebcache.googleusercontent.com%2Frobots.txt%22%2C%22https%3A%2F%2Fyandexwebcache.net%2Frobots.txt%22%2C%22https%3A%2F%2Fcc.bingj.com%2Fcache.aspx%3Fq%3Dnothing%22%2C%22https%3A%2F%2Fencrypted-tbn0.gstatic.com%2Frobots.txt%22%2C%22https%3A%2F%2Fim0-tub-com.yandex.net%2Fi%3Fid%3D462f375c96139f1e41d919b44be2d780%26n%3D13%26exp%3D1%22%2C%22https%3A%2F%2Fth.bing.com%2Fth%2Fid%2FOIP.YnpdokcN_OQYn3n41AlqZAHaEe%3Fw%3D250%26h%3D180%26c%3D7%26o%3D5%26pid%3D1.7%22%2C%22https%3A%2F%2Fexternal-content.duckduckgo.com%2Frobots.txt%22%2C%22https%3A%2F%2Fmiro.medium.com%2Frobots.txt%22%2C%22https%3A%2F%2Fcdn-client.medium.com%2Flite%2Fstatic%2Fjs%2Fmanifest.ef5f44d2.js%22%5D%7D&mv=1.2.0)