### PR TITLE
Updated CU and VE test lists

### DIFF
--- a/lists/cu.csv
+++ b/lists/cu.csv
@@ -333,3 +333,4 @@ https://eltoque.com/,NEWS,News Media,2019-05-09,ProyectoInventario y YucaByte,
 https://www.periodismodebarrio.org/,NEWS,News Media,2019-05-09,ProyectoInventario y YucaByte,
 https://desdenuestracuba.wordpress.com/,POLR,Political Criticism,2019-09-17,OONI,
 https://rialta.org/,NEWS,News Media,2020-12-15,OONI,Reportedly blocked
+https://cazadoresdefakenews.info/,POLR,Political Criticism,2021-08-20,OONI,Reportedly blocked

--- a/lists/ve.csv
+++ b/lists/ve.csv
@@ -561,3 +561,4 @@ https://sinetiquetas.org/,LGBT,LGBT,2020-05-08,Netalitica,
 https://www.homosensual.com/,LGBT,LGBT,2020-05-08,Netalitica,
 https://hablemosdesexo.com/,XED,Sex Education,2020-05-08,Netalitica,
 https://www.unifertes.com/,XED,Sex Education,2020-05-08,Netalitica,
+https://cazadoresdefakenews.info/,POLR,Political Criticism,2021-08-20,OONI,Reportedly blocked in Cuba


### PR DESCRIPTION
A site (https://cazadoresdefakenews.info/) which tracks fake news in Venezuela (through a crowdsourcing community) is reportedly blocked in Cuba (see: https://twitter.com/norges14/status/1428385486322667530).

I have added this site to both the CU and VE test lists as part of this PR.