### PR TITLE
International Rivers blocked in Indonesia

### DIFF
--- a/lists/id.csv
+++ b/lists/id.csv
@@ -660,3 +660,4 @@ http://bolauntung.com/,GMB,Gambling,2020-08-20,Netalitica,domain for sale but st
 http://fifabola.com/,GMB,Gambling,2020-08-20,Netalitica,domain for sale but still blocked
 http://bolazoom.com/,GMB,Gambling,2020-08-20,Netalitica,blocked
 https://aborsionline.org/,XED,Sex Education,2020-08-20,OONI,
+https://www.internationalrivers.org/news,ENV,Environment,2021-08-24,Arky,blocked


### PR DESCRIPTION
Added International rivers that is blocked in Indonesia. 

Perhaps related to new internet regulation

https://www.hrw.org/news/2021/05/21/indonesia-suspend-revise-new-internet-regulation