### PR TITLE
Update EG test list

### DIFF
--- a/lists/eg.csv
+++ b/lists/eg.csv
@@ -883,3 +883,4 @@ https://halacima.net/,MMED,Media sharing,2021-04-27,Masaar,
 https://medanelakhbar.com/,NEWS,News Media,2021-04-27,Masaar,
 https://www.f-secure.com/,ANON,Anonymization and circumvention tools,2021-04-27,Masaar,
 http://shadowsocks.org/,ANON,Anonymization and circumvention tools,2021-04-27,Masaar,
+https://egypt-papers.disclose.ngo/,POLR,Political Criticism,2021-11-24,OONI,Reportedly blocked


### PR DESCRIPTION
Disclose is publishing series of reports called Egypt Papers based on French intelligence leaks and docs about operations in Egypt past few years. And today they published new part focusing on surveillance (https://egypt-papers.disclose.ngo/en/chapter/surveillance-dassault). This is reportedly blocked in Egypt. 