### PR TITLE
Add https://www.dlsite.com/ to TH list

### DIFF
--- a/lists/th.csv
+++ b/lists/th.csv
@@ -443,4 +443,4 @@ https://covid19.anamai.moph.go.th/,GOVT,Government,2021-09-18,thainetizen,Depart
 https://fda.moph.go.th/,GOVT,Government,2021-09-18,thainetizen,Food and Drug Administration
 https://www.dms.go.th/,GOVT,Government,2021-09-18,thainetizen,Department of Medical Services
 https://covid19.dms.go.th/,GOVT,Government,2021-09-18,thainetizen,Department of Medical Services COVID-19 Information
-https://www.dlsite.com/,COMM,E-commerce,2021-11-30,thainetizen,Japanese anime and games online store (with adults and non-adults content) - see issue #866
+https://www.dlsite.com/,COMM,E-commerce,2021-11-30,thainetizen,Japanese anime and games online store (with adults and non-adults content) - some ISPs cannot access on 2021-11-29 - producing error 451 Unavailable for Legal Reasons - see issue #866

--- a/lists/th.csv
+++ b/lists/th.csv
@@ -443,3 +443,4 @@ https://covid19.anamai.moph.go.th/,GOVT,Government,2021-09-18,thainetizen,Depart
 https://fda.moph.go.th/,GOVT,Government,2021-09-18,thainetizen,Food and Drug Administration
 https://www.dms.go.th/,GOVT,Government,2021-09-18,thainetizen,Department of Medical Services
 https://covid19.dms.go.th/,GOVT,Government,2021-09-18,thainetizen,Department of Medical Services COVID-19 Information
+https://www.dlsite.com/,COMM,E-commerce,2021-11-30,thainetizen,Japanese anime and games online store (with adults and non-adults content) - see issue #866


### PR DESCRIPTION
A Japanese website that reported to require a Chinese Internet Content Provider license in other to view from Thailand. 

This is to close #866 (see details there)