### PR TITLE
Update in.csv (added piratebay.live to the list)

### DIFF
--- a/lists/in.csv
+++ b/lists/in.csv
@@ -610,4 +610,4 @@ http://www.macassam.nic.in/,GOVT,Government,2021-05-25,Netalitica,Mising Autonom
 https://westjaintiahills.gov.in/,GOVT,Government,2021-05-25,Netalitica,West Jaintia Hills District (autonomous region)
 https://khadc.nic.in/index.htm/,GOVT,Government,2021-05-25,Netalitica,Khasi Hills Autonomous region
 http://ttaadc.gov.in/,GOVT,Government,2021-05-25,Netalitica,Tripura Tribal Areas Council
-https://piratebay.live/,FILE,File-sharing,2022-01-02,citizenlab, Torrent hosting site blocked via DNS
+https://piratebay.live/,FILE,File-sharing,2022-01-02,community member,Torrent hosting site blocked via DNS

--- a/lists/in.csv
+++ b/lists/in.csv
@@ -610,3 +610,4 @@ http://www.macassam.nic.in/,GOVT,Government,2021-05-25,Netalitica,Mising Autonom
 https://westjaintiahills.gov.in/,GOVT,Government,2021-05-25,Netalitica,West Jaintia Hills District (autonomous region)
 https://khadc.nic.in/index.htm/,GOVT,Government,2021-05-25,Netalitica,Khasi Hills Autonomous region
 http://ttaadc.gov.in/,GOVT,Government,2021-05-25,Netalitica,Tripura Tribal Areas Council
+https://piratebay.live/,FILE,File-sharing,2022-01-02,citizenlab, Torrent hosting site blocked via DNS


### PR DESCRIPTION
piratebay.live is proxy site for piratebay.org that has been blocked in india for many years, just noticed it is not in the list so updating it.