### PR TITLE
include OSSRH Maven Central in global list

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -219,6 +219,7 @@ http://radiofreetexas.org/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI
 http://rapidgator.net/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://rarbg.to/index8.php,FILE,File-sharing,2016-08-11,sinarproject,Updated by OONI on 2017-02-14
 http://reliefweb.int/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+https://repo1.maven.org/,CTRL,Control content,2022-01-24,Community Member,OSSRH Maven Central
 http://risebroadband.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://riseup.net/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://rsf.org/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
OSSRH Maven Central is the default library repository for Java and Android projects.  It is a massive collection of open source Java libraries, including a number of circumvention tools.  It requires HTTPS so it could be a candidate for being fully blocked in order block access to specific packages that are hosted there.  It could be consdered something like GitHub or Bitbucket.