### PR TITLE
Removed http://www.mininova.org/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -740,7 +740,6 @@ http://www.metacrawler.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by
 http://www.metal-archives.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.microsofttranslator.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.mideastyouth.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.mininova.org/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.mizzima.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.moderndrunkardmagazine.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.monacogoldcasino.com/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14

--- a/lists/ir.csv
+++ b/lists/ir.csv
@@ -816,3 +816,4 @@ https://jayisgames.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://www.newgamenetwork.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://doctorsofgaming.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://indiegamesplus.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
+http://www.mininova.org/,FILE,File-sharing,2022-02-16,citizenlab,


### PR DESCRIPTION
http://www.mininova.org/ was a dead website transfered to ir.csv due to its blocked in Iran