### PR TITLE
Removed https://www.webspawner.com/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -994,7 +994,6 @@ http://www.warhammeronline.com/,GAME,Gaming,2014-04-15,citizenlab,Updated by OON
 http://www.washingtontimes.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.wcicc.org/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.webbox.com/index.php,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.webspawner.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.weebly.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.weforum.org/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.well.com/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14

--- a/lists/ir.csv
+++ b/lists/ir.csv
@@ -816,3 +816,4 @@ https://jayisgames.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://www.newgamenetwork.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://doctorsofgaming.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://indiegamesplus.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
+https://www.webspawner.com/,HOST,Hosting and Blogging Platforms,2022-02-16,citizenlab,


### PR DESCRIPTION
https://www.webspawner.com/ was a dead website transfered to ir.csv due to its blocked in Iran