### PR TITLE
Removed https://extratorrent.cc/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -88,7 +88,6 @@ https://evernote.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI o
 https://exitinternational.net/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://explorer.ooni.io/,HUMR,Human Rights Issues,2017-05-31,ADEF,probably blocked in Egypt as of 2017-05-31
 http://exscn.net/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-https://extratorrent.cc/,FILE,File-sharing,2016-08-11,sinarproject,Updated by OONI on 2017-02-14
 https://www.fanfiction.net/,CULTR,Culture,2017-10-12,sinarproject,
 http://feministing.com/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://flirtylingerie.com/,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14

--- a/lists/ir.csv
+++ b/lists/ir.csv
@@ -816,3 +816,4 @@ https://jayisgames.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://www.newgamenetwork.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://doctorsofgaming.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://indiegamesplus.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
+https://extratorrent.cc/,FILE,File-sharing,2022-02-16,citizenlab,

--- a/lists/my.csv
+++ b/lists/my.csv
@@ -492,3 +492,4 @@ http://www.sawo.org.my/,HUMR,Human Rights Issues,2021-03-29,Netalitica,"organiza
 https://www.ideas.org.my/,HUMR,Human Rights Issues,2021-03-29,Netalitica,organization promoting the level of understanding and acceptance of public policies
 https://childlinefoundation.com/,HUMR,Human Rights Issues,2021-03-29,Netalitica,organization promoting the rights of children
 https://ikram.org.my/,REL,Religion,2021-03-29,Netalitica,religious group promoting islamic values
+https://extratorrent.cc/,FILE,File-sharing,2022-02-16,citizenlab,


### PR DESCRIPTION
https://extratorrent.cc/ was a dead website transfered to ir.csv & my.csv due to its blocked in Iran and Malaysia (https://techlog360.com/rip-extratorrent/)