### PR TITLE
Removed https://torrentz.eu/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -253,7 +253,6 @@ http://timesofindia.indiatimes.com/,NEWS,News Media,2014-04-15,citizenlab,Update
 https://tinyurl.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://tor.eff.org/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://torah.org/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-https://torrentz.eu/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://translate.google.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://translate.reference.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://translation2.paralink.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14

--- a/lists/ir.csv
+++ b/lists/ir.csv
@@ -816,3 +816,4 @@ https://jayisgames.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://www.newgamenetwork.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://doctorsofgaming.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
 https://indiegamesplus.com/,GAME,Gaming,2020-07-21,oonitarian,blocked
+https://torrentz.eu/,FILE,File-sharing,2022-02-16,citizenlab,

--- a/lists/my.csv
+++ b/lists/my.csv
@@ -492,3 +492,4 @@ http://www.sawo.org.my/,HUMR,Human Rights Issues,2021-03-29,Netalitica,"organiza
 https://www.ideas.org.my/,HUMR,Human Rights Issues,2021-03-29,Netalitica,organization promoting the level of understanding and acceptance of public policies
 https://childlinefoundation.com/,HUMR,Human Rights Issues,2021-03-29,Netalitica,organization promoting the rights of children
 https://ikram.org.my/,REL,Religion,2021-03-29,Netalitica,religious group promoting islamic values
+https://torrentz.eu/,FILE,File-sharing,2022-02-16,citizenlab,


### PR DESCRIPTION
https://torrentz.eu/ was a dead website transfered to ir.csv & my.csv due to its blocked in Iran and Malaysia (https://www.news18.com/news/buzz/rip-torrentz-eu-website-bids-the-world-a-sentimental-farewell-1277997.html)