### PR TITLE
Updated RU list with blocked site

### DIFF
--- a/lists/ru.csv
+++ b/lists/ru.csv
@@ -632,3 +632,4 @@ https://teachers-union.ru/,HUMR,Human Rights Issues,2021-07-29,OONI,Reportedly b
 https://www.navalny.com/,POLR,Political Criticism,2021-07-29,OONI,Reportedly blocked
 https://stepanov2021.org/,POLR,Political Criticism,2021-07-29,OONI,Reportedly blocked
 https://www.leonidvolkov.ru/,POLR,Political Criticism,2021-07-29,OONI,Reportedly blocked
+https://200rf.com/,HUMR,Human Rights Issues,2022-03-03,OONI,Reportedly blocked


### PR DESCRIPTION
This PR adds https://200rf.com/ which shares information related to the 2022 Russian invasion of Ukraine. The site includes a banner that states that this site is blocked in Russia. We should therefore prioritize on merging this PR.