### PR TITLE
Removed dead websites

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -294,7 +294,6 @@ https://www.2600.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated on 2022-0
 http://www.2ddepot.com/,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.2shared.com/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.3wishes.com/,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.43things.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.4chan.org/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.4online-gambling.com/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.4shared.com/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -328,7 +327,6 @@ http://www.aleph.to/,MILX,Terrorism and Militants,2014-04-15,citizenlab,Updated 
 https://www.aljazeera.net/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.almanar.com.lb/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.alqassam.ps/,MILX,Terrorism and Militants,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.altavista.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.altpenis.com/,PUBH,Public Health,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.amazon.com/,COMM,E-commerce,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.americannaziparty.com/,HATE,Hate Speech,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -336,7 +334,6 @@ https://www.amnesty.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated 
 http://www.ananzi.co.za/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.angelfire.lycos.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.anglicancommunion.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.angryharry.com/,HATE,Hate Speech,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.animalliberationfront.com/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.anonymitychecker.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.anonymizer.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -928,7 +925,6 @@ http://www.tialsoft.com/download/,COMT,Communication Tools,2014-04-15,citizenlab
 http://www.tialsoft.com/multitranse/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.tmz.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.tobacco.org/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.topcities.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.topdrawers.com/,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.torproject.org/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.towleroad.com/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -1396,7 +1392,6 @@ https://libgen.space/,FILE,File-sharing,2021-02-09,Library Genesis,
 https://libgen.xyz/,FILE,File-sharing,2021-02-09,Library Genesis,
 https://forum.mhut.org/,FILE,File-sharing,2021-02-09,Library Genesis forums,
 https://libgen.life/,FILE,File-sharing,2021-02-09,Library Genesis forums,
-https://dailystormer.su/,POLR,Political Criticism,2021-02-09,,American far-right website; supposedly blocked in Europe
 https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Generic_Camera_Icon.svg/100px-Generic_Camera_Icon.svg.png,CULTR,Culture,2021-02-22,Wikimedia,URL provided by Wikimedia based on recent traffic events
 https://www.joinclubhouse.com/,GRP,Social Networking,2021-03-03,OONI,Reportedly blocked in UAE but worth testing globally
 https://nordvpn.com/,ANON,Anonymization and circumvention tools,2021-03-05,OONI,Appears to be blocked in Myanmar but worth testing globally
@@ -1519,3 +1514,4 @@ https://www.mc-doualiya.com/,NEWS,News Media,2022-02-23,OONI,
 https://mega.io/,ANON,Anonymization and circumvention tools,2022-02-27,rayasharbain,
 https://www.facebook.com/RTNews,GRP,Social Networking,2022-03-06,OONI,
 https://www.ideasbeyondborders.org/,CULTR,Culture,2022-03-16,OONI,
+https://dailystormer.name/,POLR,Political Criticism,2022-03-18,community member,American far-right website; supposedly blocked in Europe


### PR DESCRIPTION
- https://en.wikipedia.org/wiki/43_Things (The 43 Things website went offline on New Years Day, 2015.)
- https://news.yahoo.com/yahoo-shuts-down-internet-relic-182218531.html (Altavista shut down on July 8, 2013)
- https://avoiceformen.com/featured/angry-harry-passes-away/ (Website now 404 Not Found)
- Updated DailyStormer website