### PR TITLE
Added global test for starlink.com

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1519,3 +1519,4 @@ https://www.mc-doualiya.com/,NEWS,News Media,2022-02-23,OONI,
 https://mega.io/,ANON,Anonymization and circumvention tools,2022-02-27,rayasharbain,
 https://www.facebook.com/RTNews,GRP,Social Networking,2022-03-06,OONI,
 https://www.ideasbeyondborders.org/,CULTR,Culture,2022-03-16,OONI,
+https://www.starlink.com/,ANON,Anonymization and circumvention tools,2022-03-30,community member,Censorship circumvention and emergency internet access


### PR DESCRIPTION
Added global test for starlink.com, already banned in some countries due to its role in censorship circumvention and emergency internet access. Currently not tested.