### PR TITLE
Global List Cleanup

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1142,7 +1142,6 @@ http://154.35.175.225/tor/server/authority,ANON,Anonymization and circumvention 
 http://199.58.81.140/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
 http://204.13.164.118/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
 https://credibilitycoalition.org/,CULTR,Culture,2019-04-19,OONI,Reportedly inaccessible on WE in Egypt (but probably worth testing globally)
-https://black.riseup.net/,ANON,Anonymization and circumvention tools,2019-04-26,LEAP,
 https://gitlab.com/,HOST,Hosting and Blogging Platforms,2019-07-17,chelchela,
 https://dl.bintray.com/jfrog/xray/,HOST,Hosting and Blogging Platforms,2019-07-17,chelchela,
 https://upload.twitter.com/robots.txt,GRP,Social Networking,2019-07-17,chelchela,
@@ -1344,7 +1343,7 @@ https://8.8.4.4/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,
 https://1.1.1.3/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,Hosting and Blogging Platforms,2020-09-28,Chelchela,
 https://1.0.0.3/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,Hosting and Blogging Platforms,2020-09-28,Chelchela,
 https://family.cloudflare-dns.com/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,Hosting and Blogging Platforms,2020-09-28,Chelchela,
-https://download.i2p2.de/,ANON,Anonymization and circumvention tools,2020-10-16,Chelchela,
+https://i2p2.de/,ANON,Anonymization and circumvention tools,2020-10-16,Chelchela,
 https://i2pforum.net/,ANON,Anonymization and circumvention tools,2020-10-16,Chelchela,Also GRP-Social Networking
 https://muwire.com/,FILE,File-sharing,2020-10-16,Chelchela,New address for limewire.com -- Easy anonymous file sharing using I2P technology
 https://googleweblight.com/i?u=https%3A%2F%2Fexample.com%2F,ANON,Anonymization and circumvention tools,2020-11-30,Chelchela,
@@ -1484,7 +1483,6 @@ https://mask-api.icloud.com/,ANON,Anonymization and circumvention tools,2022-02-
 https://disclose.ngo/,POLR,Political Criticism,2021-11-24,OONI,Reportedly blocked in Egypt but worth testing worldwide
 https://remailer.paranoici.org/,ANON,Anonymization and circumvention tools,2022-01-04,,Type II anonymous remailer
 https://fleegle.mixmin.net/,ANON,Anonymization and circumvention tools,2022-01-04,,Type II anonymous remailer
-http://redjohn.net/,ANON,Anonymization and circumvention tools,2022-01-04,,Type II anonymous remailer
 https://www.usatoday.com/,NEWS,News Media,2022-02-15,community member,
 https://www.washingtonpost.com/,NEWS,News Media,2022-02-15,community member,
 https://www.webs.com/,HOST,Hosting and Blogging Platforms,2022-02-16,citizenlab,


### PR DESCRIPTION
Few corrections to stale URLs and Websites that are MIA. 

https://black.riseup.net/ Bitmask Black VPN is no longer available here. 
https://download.i2p2.de/ The download subdomain has moved to download page, this now points to fdroid external site.
http://redjohn.net/, RedJohn remailer website is no longer available. 
