### PR TITLE
Replaced http://www.acdi-cida.gc.ca/ with https://www.international.gc.ca/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -302,7 +302,6 @@ http://www.abortionno.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Update
 http://www.absinth.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.absolut.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.accessnow.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.acdi-cida.gc.ca/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.aceshigh.com/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.acquisitionx.com/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.actionaid.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -638,6 +637,7 @@ http://www.inetprivacy.com/,ANON,Anonymization and circumvention tools,2014-04-1
 http://www.infowar-monitor.net/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.inminds.co.uk/,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.instagram.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+https://www.international.gc.ca/,ECON,Economics,2014-04-15,citizenlab,Updated on 2022-05-15
 https://www.internationalrivers.org/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.interpol.int/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.ipcc.ch/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
https://www.cbc.ca/news/politics/federal-budget-folds-cida-into-foreign-affairs-1.1412948