### PR TITLE
Possible miscategorisation of www.answering-islam.org in MY list?

### DIFF
--- a/lists/my.csv
+++ b/lists/my.csv
@@ -129,7 +129,7 @@ https://www.asiaone.com/source/straits-times/,NEWS,News Media,2014-04-15,citizen
 https://www.abc.net.au/,NEWS,News Media,2014-04-15,citizenlab,
 https://www.agendadaily.com/,NEWS,News Media,2014-04-15,citizenlab,
 https://aliran.com/,NEWS,News Media,2014-04-15,citizenlab,
-https://www.answering-islam.org/,NEWS,News Media,2014-04-15,citizenlab,
+https://www.answering-islam.org/,REL,Religion,2014-04-15,citizenlab,
 https://asianpacificpost.com/,NEWS,News Media,2014-04-15,citizenlab,
 https://asiapacificnews.com/,NEWS,News Media,2014-04-15,citizenlab,
 https://www.bharian.com.my/,NEWS,News Media,2014-04-15,citizenlab,


### PR DESCRIPTION
Found that https://www.answering-islam.org/ is more likely a religion-related website, rather than a news media site. Could this be a possible miscategorisation?