### PR TITLE
Updated PH test list

### DIFF
--- a/lists/ph.csv
+++ b/lists/ph.csv
@@ -368,7 +368,6 @@ https://umapilipinas.wordpress.com/,POLR,Political Criticism,2022-07-12,OONI,Rep
 https://ruralmissionaries.wordpress.com/,REL,Religion,2022-07-12,OONI,Reportedly blocked
 https://rmp-national.weebly.com/,HUMR,Human Rights Issues,2022-07-12,OONI,Reportedly blocked
 https://amihanwomen.org/,HUMR,Human Rights Issues,2022-07-12,OONI,Reportedly blocked
-https://www.arkibongbayan.org/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
 https://ilps.info/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
 https://pinoyweekly.org/,NEWS,News Media,2022-07-12,OONI,Reportedly blocked
 https://www.counterpunch.org/,NEWS,News Media,2022-07-12,OONI,Reportedly blocked

--- a/lists/ph.csv
+++ b/lists/ph.csv
@@ -357,3 +357,27 @@ https://ph.oceana.org/,ENV,Environment,2018-12-27,engagemedia,
 https://www.foei.org/,ENV,Environment,2018-12-27,engagemedia,
 http://www.pemsea.org/,ENV,Environment,2018-12-27,engagemedia,
 https://ncovtracker.doh.gov.ph/,PUBH,Public Health,2020-04-01,citizenlab,coronavirus
+https://bulatlat.com/,NEWS,News Media,2022-07-12,OONI,Reportedly blocked
+https://www.bulatlat.com/,NEWS,News Media,2022-07-12,OONI,Reportedly blocked
+https://hiyaw.net/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://prwcinfo.wordpress.com/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://rctundfp.wordpress.com/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://compatriotsndf.wordpress.com/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://saveourschoolsnetwork.wordpress.com/,HUMR,Human Rights Issues,2022-07-12,OONI,Reportedly blocked
+https://umapilipinas.wordpress.com/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://ruralmissionaries.wordpress.com/,REL,Religion,2022-07-12,OONI,Reportedly blocked
+https://rmp-national.weebly.com/,HUMR,Human Rights Issues,2022-07-12,OONI,Reportedly blocked
+https://amihanwomen.org/,HUMR,Human Rights Issues,2022-07-12,OONI,Reportedly blocked
+https://www.arkibongbayan.org/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://ilps.info/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://pinoyweekly.org/,NEWS,News Media,2022-07-12,OONI,Reportedly blocked
+https://www.counterpunch.org/,NEWS,News Media,2022-07-12,OONI,Reportedly blocked
+https://iacenter.org/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://monthlyreview.org/,NEWS,News Media,2022-07-12,OONI,Reportedly blocked
+https://pamalakayaweb.wordpress.com/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://angpamalakaya.org/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://peoples-march.blogspot.com/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://ndfp.org/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://liberation.ndfp.org/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked
+https://blog-by-taga-ilog-news.blogspot.com/,NEWS,News Media,2022-07-12,OONI,Reportedly blocked
+http://partisan-news.blogspot.com/,POLR,Political Criticism,2022-07-12,OONI,Reportedly blocked


### PR DESCRIPTION
This PR adds a number of websites that are reportedly blocked in the Philippines according to news articles (such as https://www.rappler.com/newsbreak/iq/list-websites-esperon-blocked-progressive-groups-news-organizations-philippines/) and reports from community members.