### PR TITLE
Added TikTok endpoints to AZ test list

### DIFF
--- a/lists/az.csv
+++ b/lists/az.csv
@@ -78,7 +78,6 @@ https://www.meydan.tv/az/,NEWS,News Media,2022-07-26,test-lists.ooni.org contrib
 https://toplum.tv/,NEWS,News Media,2022-07-26,test-lists.ooni.org contribution,
 https://smdtaz.org/,HUMR,Human Rights Issues,2022-07-26,test-lists.ooni.org contribution,
 https://news.az/,NEWS,News Media,2022-07-27,test-lists.ooni.org contribution,
-https://www.tiktok.com/,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://webcast.tiktok.com/webcast/wallet_api/diamond_buy/permission/,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://vmweb-va.byteoversea.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://v16-webapp.tiktok.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
@@ -88,7 +87,6 @@ https://sf16-scmcdn-va.ibytedtos.com/obj/static-us/secsdk/secsdk-lastest.umd.js,
 https://s20.tiktokcdn.com/tiktok/common/init.js,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://p77-va.tiktokcdn.com/img/tos-useast2a-v-2774/4fcd4d23462548b3a4ca332ddf8bd6bd~c5_100x100.jpeg,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://p77-sign-va.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
-https://p19-sign.tiktokcdn-us.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://p19-sign.tiktokcdn-us.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://p16-sign-va.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://mssdk-va.tiktok.com/web/resource,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today

--- a/lists/az.csv
+++ b/lists/az.csv
@@ -100,3 +100,5 @@ https://lf16-tiktok-common.ttwstatic.com/robots.txt,GRP,Social Networking,2022-0
 https://p16-sign-sg.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://sf77-ies-music-sg.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://p77-sign-sg-lite.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://starling-oversea.byteoversea.com/check_and_get_text/5dc26cf008d511e9b571e1bc0c9e23b5/normal/WebApp_Login?lang=en,zh&version=1661412130727425024,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://m.tiktok.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today

--- a/lists/az.csv
+++ b/lists/az.csv
@@ -78,3 +78,27 @@ https://www.meydan.tv/az/,NEWS,News Media,2022-07-26,test-lists.ooni.org contrib
 https://toplum.tv/,NEWS,News Media,2022-07-26,test-lists.ooni.org contribution,
 https://smdtaz.org/,HUMR,Human Rights Issues,2022-07-26,test-lists.ooni.org contribution,
 https://news.az/,NEWS,News Media,2022-07-27,test-lists.ooni.org contribution,
+https://www.tiktok.com/,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://webcast.tiktok.com/webcast/wallet_api/diamond_buy/permission/,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://vmweb-va.byteoversea.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://v16-webapp.tiktok.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://sf16-short-va.bytedapm.com/slardar/fe/sdk_lite/plugins/sample.1.1.0.maliva.js,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://sf16-secsdk.ttwstatic.com/obj/rc-web-sdk-gcs/webmssdk/1.0.0.449/webmssdk.js,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://sf16-scmcdn-va.ibytedtos.com/obj/static-us/secsdk/secsdk-lastest.umd.js,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://s20.tiktokcdn.com/tiktok/common/init.js,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://p77-va.tiktokcdn.com/img/tos-useast2a-v-2774/4fcd4d23462548b3a4ca332ddf8bd6bd~c5_100x100.jpeg,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://p77-sign-va.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://p19-sign.tiktokcdn-us.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://p19-sign.tiktokcdn-us.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://p16-sign-va.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://mssdk-va.tiktok.com/web/resource,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://mon-va.byteoversea.com/monitor_web/settings/browser-settings?bid=webmssdk&store=1,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://mcs-va.tiktok.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://lf16-web.tiktokcdn.com/obj/tiktok-web-wp-us/wp-content/uploads/2021/05/accImg4.png,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://lf16-tiktok-web.ttwstatic.com/obj/tiktok-web-us/tiktok/webapp/main/webapp-mobile/runtime.55b64d1527fbff92816c.js,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://lf16-tiktok-common.ibytedtos.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://lf16-tiktok-web.neutral.ttwstatic.com/obj/bd-s3-va-tos-tiktok-web-neutral-us/pns/tiktok-cookie-banner/mali_va/1.0.0.101/web/web.esm.js,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://lf16-tiktok-common.ttwstatic.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://p16-sign-sg.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://sf77-ies-music-sg.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://p77-sign-sg-lite.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today

--- a/lists/az.csv
+++ b/lists/az.csv
@@ -100,5 +100,5 @@ https://lf16-tiktok-common.ttwstatic.com/robots.txt,GRP,Social Networking,2022-0
 https://p16-sign-sg.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://sf77-ies-music-sg.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://p77-sign-sg-lite.tiktokcdn.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
-https://starling-oversea.byteoversea.com/check_and_get_text/5dc26cf008d511e9b571e1bc0c9e23b5/normal/WebApp_Login?lang=en,zh&version=1661412130727425024,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
+https://starling-oversea.byteoversea.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today
 https://m.tiktok.com/robots.txt,GRP,Social Networking,2022-09-14,OONI,TikTok reportedly blocked in Azerbaijan today


### PR DESCRIPTION
We're receiving reports that the TikTok app may have been blocked in Azerbaijan today. This PR therefore adds TikTok endpoints to the AZ test list. 

I've refrained from adding these endpoints to the Global test list, as it's quite a long list of endpoints (whereas the AZ list -- where the blocking is being reported -- is short). We could potentially remove these endpoints from the AZ list (and potentially add some or all of them to the Global list) once we've collected enough data over the next weeks to investigate this case. 