### PR TITLE
Adds blocked websites in france and update scihub-libgen urls in global

### DIFF
--- a/lists/fr.csv
+++ b/lists/fr.csv
@@ -14,3 +14,20 @@ https://fr.m.wikisource.org/,CULTR,Culture,2019-06-07,Wikimedia,URLs provided by
 https://nantes.indymedia.org/,NEWS,News Media,2019-09-27,Community Member,Independent media threatened to be blocked by the police https://nantes.indymedia.org/articles/44313
 https://grenoble.indymedia.org/,NEWS,News Media,2019-09-27,Community Member,Independent media threatened to be blocked by the police
 https://democratieparticipative.icu/,POLR,Political Criticism,2021-02-09,,Far-right website - reportedly blocked (see https://francais.rt.com/france/55943-neuf-operateurs-sommes-par-justice-bloquer-acces-site-raciste-democratie-participative)
+https://z-lib.org/,FILE,File-sharing,2022-09-26,Community Member,Z-library is going to be blocked by French Justice
+https://b-ok.xyz/,FILE,File-sharing,2022-09-26,Community Member,Z-library is going to be blocked by French Justice
+https://fr.booksc.org/,FILE,File-sharing,2022-09-26,Community Member,Z-library is going to be blocked by French Justice
+https://booksc.org/,FILE,File-sharing,2022-09-26,Community Member,Z-library is going to be blocked by French Justice
+https://beinmatch.site/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+https://beinmatch.tv/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+https://beinmatchtv.tv/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+https://kooora4live.net/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+https://kooora4lives.net/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+https://kooora4lives.com/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+https://tv.kora-star.com/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+http://livetv.sx/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+http://cdn.livetv491.me/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+https://www.mysports.to/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+https://sportnews.to/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+http://freestreams-live1.com/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website
+https://www.aflam4you.net/,MMED,Media sharing,2022-09-26,Community Member,blocked streaming website

--- a/lists/global.csv
+++ b/lists/global.csv
@@ -187,6 +187,7 @@ https://rsf.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI 
 http://russia.tv/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://sakhr.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://sci-hub.se/,FILE,File-sharing,2019-09-27,Community Member,New sci-hub domain
+https://sci.hubg.org/,FILE,File-sharing,2022-09-26,Community Member,New sci-hub domain
 https://search.aol.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://seclists.org/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://secfirst.org/,HUMR,Human Rights Issues,2018-07-05,Security First,
@@ -1127,7 +1128,7 @@ https://www.eurobicon.org/,LGBT,LGBT,2019-11-18,OutRight International,
 https://etherscan.io/,COMM,E-commerce,2019-12-04,OONI,blocked in china according to https://www.coindesk.com/chinas-internet-firewall-has-blocked-access-to-ethereum-block-explorer-etherscan-io
 https://dns.google/,HOST,Hosting and Blogging Platforms,2019-12-04,Chelchela,
 https://slate.com/,NEWS,News Media,2020-01-08,OONI,
-https://kiwifarms.net/,GRP,Social Networking,2022-01-24,,blocked in Russia 
+https://kiwifarms.net/,GRP,Social Networking,2022-01-24,,blocked in Russia
 https://getintra.org/,ANON,Anonymization and circumvention tools,2020-02-03,OONI,
 https://www.caixinglobal.com/2020/coronavirus/,PUBH,Public Health,2020-02-04,OONI,coronavirus
 https://gisanddata.maps.arcgis.com/apps/opsdashboard/index.html#/bda7594740fd40299423467b48e9ecf6,PUBH,Public Health,2020-02-04,Community member,coronavirus
@@ -1244,7 +1245,7 @@ https://telegram.me/,COMT,Communication Tools,2020-06-04,Chelchela,
 https://telegra.ph/,HOST,Hosting and Blogging Platforms,2019-08-30,OONI partner,
 https://www.spotify.com/,CULTR,Culture,2020-06-04,Chelchela,
 https://www.globalpride2020.org/,LGBT,LGBT,2020-06-18,citizenlab,Global
-http://tanzil.net/,REL,Religion,2017-03-09,CIPIT,Multilingual Quran -- Blocked in China 
+http://tanzil.net/,REL,Religion,2017-03-09,CIPIT,Multilingual Quran -- Blocked in China
 https://quran.com/?local=en,REL,Religion,2020-06-13,Chelchela,Multilingual Quran -- Not accessible in several countries
 https://trello.com/,COMT,Communication Tools,2020-07-16,Chelchela,
 https://dns.adguard.com/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,Hosting and Blogging Platforms,2020-07-16,Chelchela,Adguard DNS over HTTPS; query is for www.example.com.
@@ -1292,6 +1293,7 @@ http://libgen.lc/,FILE,File-sharing,2021-02-09,Library Genesis,
 http://libgen.li/,FILE,File-sharing,2021-02-09,Library Genesis,
 https://libgen.fun/,FILE,File-sharing,2021-02-09,Library Genesis,
 https://libgen.me/,FILE,File-sharing,2021-02-09,Library Genesis,
+https://www.libgen.tw/,FILE,File-sharing,2022-09-26,Library Genesis,
 https://libgen.space/,FILE,File-sharing,2021-02-09,Library Genesis,
 https://libgen.xyz/,FILE,File-sharing,2021-02-09,Library Genesis,
 https://forum.mhut.org/,FILE,File-sharing,2021-02-09,Library Genesis forums,


### PR DESCRIPTION
Hi,

This PR does two things : 
* Adds new sci-hub and libgen urls in the global list
* Adds zlib and streaming sites in the French list (all supposed to be blocked or blocked soon, see [this](https://www.nextinpact.com/article/49593/bein-sports-fait-bloquer-18-sites-streaming-illicites-en-france) and [this](https://actualitte.com/article/107899/droit-justice/piratage-le-blocage-du-site-z-library-ordonne-par-la-justice-francaise))

Let me know if anything is not correct in the format.