### PR TITLE
Remove news.kqube.net from KH

### DIFF
--- a/lists/kh.csv
+++ b/lists/kh.csv
@@ -17,7 +17,6 @@ http://km.rfi.fr/,NEWS,News Media,2018-08-01,sinarproject,Independent online new
 https://kohsantepheapdaily.com.kh/,NEWS,News Media,2016-10-06,OONI,
 http://mlup-baitong.org/,POLR,Political Criticism,2018-08-01,sinarproject,
 https://news.e-khmer.com/,NEWS,News Media,2016-10-06,OONI,
-http://news.kqube.net/,NEWS,News Media,2016-10-06,OONI,
 http://nokorwatnews.com/,NEWS,News Media,2016-10-06,OONI,
 https://www.pinterest.de/pin/408490628686118654/,GRP,Social Networking,2018-08-01,sinarproject,
 http://phnompenhpride.blogspot.com/,LGBT,LGBT,2016-10-06,OONI,


### PR DESCRIPTION
Removing expired news.kqube.net from KH list. 
