### PR TITLE
Remove pof.com from Global

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -734,7 +734,6 @@ https://www.planetromeo.com/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 
 https://www.plannedparenthood.org/,XED,Sex Education,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.playboy.com/,PORN,Pornography,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.pmi.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.pof.com/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.pogo.com/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.poker.com/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.pokerpages.com/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Remove pof.com domain from Global lists. The service is no longer online, visiting the site results in 404 page.

https://explorer.ooni.org/chart/mat?test_name=web_connectivity&input=http%3A%2F%2Fwww.pof.com%2F&since=2022-09-01&until=2022-10-01&axis_x=measurement_start_day
