### PR TITLE
Remove infowar-monitor.net from Global

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -568,7 +568,6 @@ http://www.implantinfo.com/,PUBH,Public Health,2014-04-15,citizenlab,Updated by 
 http://www.inbox.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.indiatimes.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.inetprivacy.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.infowar-monitor.net/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.inminds.co.uk/,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.instagram.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.international.gc.ca/,ECON,Economics,2014-04-15,citizenlab,Updated on 2022-05-15


### PR DESCRIPTION
Remove inactive website www.infowar-monitor.net from global lists.

https://explorer.ooni.org/chart/mat?test_name=web_connectivity&input=http%3A%2F%2Fwww.infowar-monitor.net%2F&since=2022-09-01&until=2022-10-01&axis_x=measurement_start_day