### PR TITLE
Remove asstr.org from Global

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -14,7 +14,6 @@ http://anonymouse.org/,ANON,Anonymization and circumvention tools,2014-04-15,cit
 https://archive.org/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://archiveofourown.org/,CULTR,Culture,2017-10-25,sinarproject,
 https://asiatimes.com/,NEWS,News Media,2014-04-15,citizenlab,Updated on 2022-02-27
-https://www.asstr.org/,CULTR,Culture,2019-10-17,sinarproject,erotic fiction
 https://astalavista.box.sk/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://attrition.org/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://secure.avaaz.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Removing inactive website www.asstr.org from global list. 

https://explorer.ooni.org/chart/mat?test_name=web_connectivity&input=http%3A%2F%2Fwww.asstr.org%2F&since=2022-09-01&until=2022-10-01&axis_x=measurement_start_day