### PR TITLE
Remove www.hivandhepatitis.com from Global

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -520,7 +520,6 @@ https://thehiddenwiki.org/,MISC,Miscelaneous content,2017-08-15,A.Gh.,blocked in
 https://www.hidemyass.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.hightail.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.hitler.org/,CULTR,Culture,2014-04-15,citizenlab,Updated on 2022-02-27
-http://www.hivandhepatitis.com/,PUBH,Public Health,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.hizb-ut-tahrir.org/,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.hon.ch/,PUBH,Public Health,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.honduras.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Remove inaccessible and offline website www.hivandhepatitis.com from Global

https://explorer.ooni.org/chart/mat?test_name=web_connectivity&input=http%3A%2F%2Fwww.hivandhepatitis.com%2F&since=2022-09-01&until=2022-10-01&axis_x=measurement_start_day