### PR TITLE
Remove everyday.com.kh

### DIFF
--- a/lists/kh.csv
+++ b/lists/kh.csv
@@ -43,8 +43,7 @@ https://www.central-cambodia.org/,HUMR,Human Rights Issues,2018-08-01,sinarproje
 http://www.chrac.org/,HUMR,Human Rights Issues,2016-10-06,OONI,
 http://www.cpp.org.kh/,GOVT,Government,2016-09-17,cchr,Current ruling political party
 http://www.dap-news.com/,NEWS,News Media,2016-10-06,OONI,
-http://www.dtn7.com/,NEWS,News Media,2018-08-01,sinarproject,
-http://www.everyday.com.kh/,NEWS,News Media,2016-10-06,OONI,
+http://www.dtn7.com/,NEWS,News Media,2018-08-01,sinarproject,   
 https://www.facebook.com/cambodiapride/,LGBT,LGBT,2016-10-06,OONI,
 http://www.facebook.com/cambodiapride/,LGBT,LGBT,2016-10-06,OONI,
 http://www.freshnewsasia.com/,NEWS,News Media,2018-08-01,sinarproject,


### PR DESCRIPTION
Remove news site that is no longer active http://www.everyday.com.kh/

https://explorer.ooni.org/chart/mat?test_name=web_connectivity&input=http%3A%2F%2Fwww.everyday.com.kh%2F&since=2022-09-06&until=2022-10-06&axis_x=measurement_start_day