### PR TITLE
Removed CHRAC.org

### DIFF
--- a/lists/kh.csv
+++ b/lists/kh.csv
@@ -40,7 +40,6 @@ http://www.ccc-cambodia.org/en/ngodb/ngo-information/666,POLR,Political Criticis
 https://www.ccimcambodia.org/,POLR,Political Criticism,2018-08-01,sinarproject,
 http://www.cen.com.kh/home,NEWS,News Media,2016-10-06,OONI,
 https://www.central-cambodia.org/,HUMR,Human Rights Issues,2018-08-01,sinarproject,
-http://www.chrac.org/,HUMR,Human Rights Issues,2016-10-06,OONI,
 http://www.cpp.org.kh/,GOVT,Government,2016-09-17,cchr,Current ruling political party
 http://www.dap-news.com/,NEWS,News Media,2016-10-06,OONI,
 http://www.dtn7.com/,NEWS,News Media,2018-08-01,sinarproject,


### PR DESCRIPTION
Removing defunct website of CHRAC.org  

https://explorer.ooni.org/chart/mat?test_name=web_connectivity&input=http%3A%2F%2Fwww.chrac.org&since=2021-10-05&until=2022-10-05&axis_x=measurement_start_day