### PR TITLE
Remove defunct coronavirus-map.com

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1171,7 +1171,6 @@ https://multimedia.scmp.com/infographics/news/china/article/3047038/wuhan-virus/
 https://www.nbcnewyork.com/news/national-international/map-watch-the-coronavirus-cases-spread-across-the-world/2303276/,PUBH,Public Health,2020-03-21,OONI,coronavirus
 https://nextstrain.org/ncov,PUBH,Public Health,2020-03-21,OONI,coronavirus
 https://coronavirus.app/,PUBH,Public Health,2020-03-27,magma,coronavirus; Blocked in PT: https://revolucaodosbytes.pt/a-nos-e-o-bloqueio-de-dominios-legitimos/
-https://coronavirus-map.com/,PUBH,Public Health,2020-03-27,magma,coronavirus; Blocked in PT: https://revolucaodosbytes.pt/a-nos-e-o-bloqueio-de-dominios-legitimos/
 https://bit.ly/,HOST,Hosting and Blogging Platforms,2020-03-27,magma,Blocked in PT: https://revolucaodosbytes.pt/nos-bloqueia-bit-ly/
 https://bitly.com/,HOST,Hosting and Blogging Platforms,2020-03-27,magma,
 http://discord.gg/,COMT,Communication Tools,2020-03-27,magma,Blocked in PT: https://revolucaodosbytes.pt/a-nos-e-o-bloqueio-de-dominios-legitimos/


### PR DESCRIPTION
The coronavirus-map.com website is no longer active. Suggest removing it from measurements. 