### PR TITLE
Removing 150m.com and ecotours.150m.com

### DIFF
--- a/lists/gh.csv
+++ b/lists/gh.csv
@@ -24,7 +24,6 @@ http://datememateme.com/dating/ghana/accra-ghana/accra-33,DATE,Online Dating,201
 http://desiredland.wixsite.com/glorygcfi,REL,Religion,2016-11-24,OONI,
 http://druginfo.adf.org.au/,ALDR,Alcohol & Drugs,2016-11-24,OONI,
 http://drumghana.tripod.com/multiculturalstudies/,CULTR,Culture,2016-11-24,OONI,
-http://ecotours.150m.com/,CULTR,Culture,2016-11-30,OONI partner,"Content relating to entertainment, history, literature, music, film, books, satire and humour"
 http://eleganthomesgh.com/,COMM,E-commerce,2016-11-30,OONI partner,Websites of commercial services and products
 http://elminabayresort.com/,CULTR,Culture,2016-11-30,OONI partner,"Content relating to entertainment, history, literature, music, film, books, satire and humour"
 http://eshopafrica.com/,COMM,E-commerce,2016-11-30,OONI partner,Websites of commercial services and products

--- a/lists/global.csv
+++ b/lists/global.csv
@@ -249,7 +249,6 @@ https://worldsingles.com/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OO
 https://wupj.org/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://wwf.panda.org/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.100webspace.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.150m.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.2600.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated on 2022-02-27
 https://www.2shared.com/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.3wishes.com/,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Hosting and blogging platform 150m.com is currently not online for the last year or so. propose removing this from our test lists. 

/cc @sloncocs @agrabeli 

https://explorer.ooni.org/chart/mat?test_name=web_connectivity&input=http%3A%2F%2Fwww.150m.com&since=2021-10-12&until=2022-10-12&axis_x=measurement_start_day