### PR TITLE
lists/ir.csv: fix handle link

### DIFF
--- a/lists/ir.csv
+++ b/lists/ir.csv
@@ -225,7 +225,7 @@ https://www.fandom.com/,CULTR,Culture,2017-09-05,OONI,blocked with 503 error cod
 https://www.camsoda.com/,PORN,Pornography,2017-09-05,OONI,blocked
 https://ir.true.com/press-releases/,COMM,E-commerce,2017-09-05,OONI,blocked with timeout error.
 https://tgp.babesnetwork.com/,PORN,Pornography,2017-09-05,OONI,blocked
-https://cgspace.cgiar.org/handle/10568/91553/,SRCH,Search Engines,2018-04-01,Alan Orth,Handle.net provides persistent identifiers for items in academic repositories. Blocked
+https://hdl.handle.net/10568/91553,SRCH,Search Engines,2018-04-01,Alan Orth,Handle.net provides persistent identifiers for items in academic repositories. Blocked
 http://graphicriver.net/,MMED,Media sharing,2017-05-16,ASL19,The site has blocked Iranian ip.
 http://www.alrased.net/main/,REL,Religion,2014-04-15,citizenlab,language is Arabic
 http://www.islamicweb.com/Arabic/Shia/,HUMR,Human Rights Issues,2014-04-15,citizenlab,blocked


### PR DESCRIPTION
This was supposed to be testing resolution of the hdl.handle.net do- main itself, not what the Handle link resolves to (Handles are like DOIs, where a persistent identifier points to a resource on another domain). We had a case of hdl.handle.net being blocked in Iran (not sure if still the case).

This test was erroneously updated to point to the resolved resource (I suspect someone used a script to update the list, because the Handle service would have returned an HTTP redirect). Furthermore, a trailing slash on this URL is not even valid (returns HTTP 404).

See: https://github.com/citizenlab/test-lists/pull/323
See: 34cac1b5b881404faf21ee9bf11f33945bd77129