### PR TITLE
chore(it.csv): zap parked/nonexisting domains

### DIFF
--- a/lists/it.csv
+++ b/lists/it.csv
@@ -18,7 +18,6 @@ http://putlocker.is/,FILE,File-sharing,2017-04-12,,Site reported to be blocked b
 http://watchseries.ag/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://mp3lemon.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://portalzuca.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
-http://itsat.info/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://mp3zitrone.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://solarmovie.is/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://watchserieshd.eu/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
@@ -43,7 +42,6 @@ http://stardelcinema.org/,FILE,File-sharing,2017-04-12,,Site reported to be bloc
 http://myfreemp3.biz/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://busca.co/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://mp3cool.me/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
-http://cinemalibero.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://masmp3s.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://streamingdb.co/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://mptri.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
@@ -89,7 +87,6 @@ http://iwannawatch.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocke
 http://thecineblog01.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://redmp3.cc/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://mp3int.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
-http://cineblog01.fm/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://mp3.plus/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://filmpertutti.co/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://filmpertutti.eu/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
@@ -151,7 +148,6 @@ http://marapcana.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked 
 http://btso.pw/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://altadefinizione.io/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://cb01.co/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
-http://cinemasubito.me/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://mp3va.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://altadefinizione.cc/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://vertuha.xyz/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
@@ -159,7 +155,6 @@ http://mp3songx.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked b
 http://mp3fiesta.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://torlock.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://cineblog01.name/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
-http://portalehd.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://pdfmag.org/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://fiesta-music.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://marapcana.org/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
@@ -174,7 +169,6 @@ http://livetv111.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked 
 http://livetv110.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://livetv107.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://livetv104.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
-http://livetv102.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://giostreams.eu/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://live2all.me/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://onlinemacizle.org/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
@@ -192,12 +186,10 @@ http://conexaomp3.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked
 http://guardarefilm.co/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://altadefinizione.love/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://altadefinizione01.top/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
-http://marapcana.club/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://emp3world.ch/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://wrzuta.pl/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://altadefinizione.blue/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://xhdstream.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
-http://extreme-down.me/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://estrenosli.org/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://seekasong.com/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication
 http://cineblog01hd.net/,FILE,File-sharing,2017-04-12,,Site reported to be blocked by AGCOM - Italian Autority on Communication


### PR DESCRIPTION
This diff deletes a bunch of domains that we found to be parked or nonexisting a while ago when testing web connectivity.

All these domains are part of the Italian test list.

They all have some residual censorship, but we've been favouring existing websites recently, so I think this diff makes sense.

Closes https://github.com/ooni/probe/issues/2316

Closes https://github.com/ooni/probe/issues/2315

Closes https://github.com/ooni/probe/issues/2314

Closes https://github.com/ooni/probe/issues/2312

Closes https://github.com/ooni/probe/issues/2302

Closes https://github.com/ooni/probe/issues/2308

Closes https://github.com/ooni/probe/issues/2304

Closes https://github.com/ooni/probe/issues/2310