### PR TITLE
Add UA blocked media to RU list

### DIFF
--- a/lists/ru.csv
+++ b/lists/ru.csv
@@ -736,3 +736,4 @@ https://www.ekhokavkaza.com/,NEWS,News Media,2022-11-09,test-lists.ooni.org cont
 https://reestr.rublacklist.net/,HUMR,Human Rights Issues,2022-12-09,test-lists.ooni.org contribution,
 https://vlast.kz/,NEWS,News Media,2022-12-16,test-lists.ooni.org contribution,"Kazakh media covering the war, was blocked in Russia in December 2022"
 https://getfinance.ru/,COMM,E-commerce,2023-01-26,OONI,uses Russian root CA
+https://www.epravda.com.ua/,NEWS,News Media,2023-02-18,OONI,Ukrainian site reportedly blocked in Russia


### PR DESCRIPTION
This PR adds a Ukrainian news media site (https://www.epravda.com.ua/) that is reportedly blocked in Russia (https://roskomsvoboda.org/post/hromadske-blocked/).