### PR TITLE
Removed defunt CNRP7 and RFA entry

### DIFF
--- a/lists/kh.csv
+++ b/lists/kh.csv
@@ -5,7 +5,6 @@ http://blog.conservation.org/2013/11/in-cambodia-environmental-challenges-mirror
 https://cambodian.dating/,DATE,Online Dating,2016-10-06,OONI,
 http://camnews.com.kh/,NEWS,News Media,2016-10-06,OONI,
 https://cchrcambodia.org/,HUMR,Human Rights Issues,2016-09-17,cchr,Human Rights Organization
-http://www.cnrp7.org/,POLR,Political Criticism,2018-08-01,sinarproject,Political Party
 http://cipocambodia.org/,HUMR,Human Rights Issues,2018-08-01,sinarproject,
 https://comfrel.org/,POLR,Political Criticism,2018-08-01,sinarproject,
 https://humanrightsinasean.info/,HUMR,Human Rights Issues,2018-08-01,sinarproject,
@@ -63,7 +62,6 @@ http://www.ngoforum.org.kh/,POLR,Political Criticism,2018-08-01,sinarproject,
 https://www.phnompenhpost.com/,NEWS,News Media,2016-10-06,OONI,
 http://www.ponlokkhmer.org/,HUMR,Human Rights Issues,2018-08-01,sinarproject,
 https://www.postkhmer.com/,NEWS,News Media,2018-08-01,sinarproject,
-http://www.rfa.org/english/news/cambodia,NEWS,News Media,2016-10-06,OONI,
 https://www.rsvp.com.au/browse/CAMBODIA.jsp,DATE,Online Dating,2016-10-06,OONI,
 http://www.sabay.com.kh/,NEWS,News Media,2018-08-01,sinarproject,
 http://www.thmeythmey.com/,NEWS,News Media,2018-08-01,sinarproject,
@@ -80,7 +78,6 @@ https://cambojanews.com/,NEWS,News Media,2021-06-02,OONI,
 https://khmer.cambojanews.com/,NEWS,News Media,2021-06-02,OONI,
 https://vodenglish.news/,NEWS,News Media,2021-06-02,OONI,
 https://vodkhmer.news/,NEWS,News Media,2021-06-02,OONI,
-https://www.rfa.org/khmer/,NEWS,News Media,2021-06-02,OONI,Reportedly blocked in 2018
 https://www.monorom.info/,NEWS,News Media,2021-06-02,OONI,Reportedly blocked in 2018
 https://opendevelopmentcambodia.net/tag/independent-network-for-social-justice/,NEWS,News Media,2021-06-02,OONI,Reportedly blocked in 2018
 http://vithyu.com/,NEWS,News Media,2021-06-02,OONI,Reportedly blocked in 2018


### PR DESCRIPTION
Removing defunct CNRP7 domain name. 

Removing RFA.org which is already in Global list. 