### PR TITLE
Drop tor directory authorities from global list

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1052,16 +1052,6 @@ https://ar.m.wikipedia.org/,CULTR,Culture,2019-02-19,Wikimedia,URLs provided by 
 https://en.m.wikipedia.org/,CULTR,Culture,2019-02-19,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://es.m.wikipedia.org/,CULTR,Culture,2019-02-19,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://pt.m.wikipedia.org/,CULTR,Culture,2019-02-19,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
-http://128.31.0.39:9131/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
-http://86.59.21.38/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
-http://194.109.206.212/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
-http://66.111.2.131:9030/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
-http://131.188.40.189/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
-http://193.23.244.244/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
-http://171.25.193.9:443/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
-http://154.35.175.225/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
-http://199.58.81.140/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
-http://204.13.164.118/tor/server/authority,ANON,Anonymization and circumvention tools,2019-03-19,magma,Tor directory authority
 https://credibilitycoalition.org/,CULTR,Culture,2019-04-19,OONI,Reportedly inaccessible on WE in Egypt (but probably worth testing globally)
 https://gitlab.com/,HOST,Hosting and Blogging Platforms,2019-07-17,chelchela,
 https://dl.bintray.com/jfrog/xray/,HOST,Hosting and Blogging Platforms,2019-07-17,chelchela,


### PR DESCRIPTION
These are already being tested as part of the tor reachability test. No need to duplicate coverage.