### PR TITLE
Global: Remove MuWire

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1252,7 +1252,6 @@ https://1.0.0.3/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,
 https://family.cloudflare-dns.com/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB,HOST,Hosting and Blogging Platforms,2020-09-28,Chelchela,
 https://i2p2.de/,ANON,Anonymization and circumvention tools,2020-10-16,Chelchela,
 https://i2pforum.net/,ANON,Anonymization and circumvention tools,2020-10-16,Chelchela,Also GRP-Social Networking
-https://muwire.com/,FILE,File-sharing,2020-10-16,Chelchela,New address for limewire.com -- Easy anonymous file sharing using I2P technology
 https://googleweblight.com/i?u=https%3A%2F%2Fexample.com%2F,ANON,Anonymization and circumvention tools,2020-11-30,Chelchela,
 https://makeamazonpay.com/,POLR,Political Criticism,2020-11-30,OONI,
 https://www.eventbrite.com/,CULTR,Culture,2020-12-15,OONI Partner,


### PR DESCRIPTION
MuWire was a file sharing program that used the I2P network. However, the main developer gave up development and his work on I2P in general for personal reasons. It seems he could not find a successor / maintainer for the project.

Both the website and the seed/bootstrap servers for MuWire are dead.

see https://www.reddit.com/r/i2p/comments/zs1x5j/muwire_is_down/ and https://www.reddit.com/r/i2p/comments/112fmb9/muwire_shutdown/