### PR TITLE
Update sy.csv

### DIFF
--- a/lists/sy.csv
+++ b/lists/sy.csv
@@ -529,3 +529,4 @@ http://www.m3loma.com/sedu/,XED,Sex Education,2014-04-15,citizenlab,
 https://salamatechwiki.org/,ANON,Anonymization and circumvention tools,2020-11-21,Jarrousse,regional MENA relevance
 https://sputnikarabic.ae/,NEWS,News Media,2023-04-24,test-lists.ooni.org contribution,
 https://arij.net/,NEWS,News Media,2023-08-09,test-lists.ooni.org contribution,Investigative journalism working accross Mena
+https://arabfcn.net/ ,NEWS,Media,2023-08-10,Saeedroy, is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region


### PR DESCRIPTION
Added AFCN website, The Arab Fact-Checkers Network (AFCN) is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region. This network is a product of the mis/disinformation spikes amid the unprecedented times of COVID-19 worldwide.