### PR TITLE
Update ye.csv

### DIFF
--- a/lists/ye.csv
+++ b/lists/ye.csv
@@ -961,3 +961,4 @@ https://www.dwturkce.com/,NEWS,News Media,2023-04-14,OONI,
 https://www.dwelle.eu/,NEWS,News Media,2023-04-14,OONI,
 https://sputnikarabic.ae/,NEWS,News Media,2023-04-24,test-lists.ooni.org contribution,
 https://arij.net/,NEWS,News Media,2023-08-09,test-lists.ooni.org contribution,Investigative journalism working accross Mena
+https://arabfcn.net/ ,NEWS,Media,2023-08-10,Saeedroy, is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region


### PR DESCRIPTION
Added AFCN website, The Arab Fact-Checkers Network (AFCN) is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region. This network is a product of the mis/disinformation spikes amid the unprecedented times of COVID-19 worldwide.