### PR TITLE
Update tr.csv

### DIFF
--- a/lists/tr.csv
+++ b/lists/tr.csv
@@ -421,3 +421,4 @@ https://firatnews.com/,NEWS,News Media,2023-05-05,test-lists.ooni.org contributi
 https://www.dogrulukpayi.com/,POLR,Political Criticism,2023-05-14,test-lists.ooni.org contribution,
 https://eksisozluk1923.com/,GRP,Social Networking,2023-05-25,test-lists.ooni.org contribution,https://eksisozluk2023.com/ new url
 https://arij.net/,NEWS,News Media,2023-08-09,test-lists.ooni.org contribution,Investigative journalism working accross Mena
+https://arabfcn.net/ ,NEWS,Media,2023-08-10,Saeedroy, is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region


### PR DESCRIPTION
Added AFCN website, The Arab Fact-Checkers Network (AFCN) is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region. This network is a product of the mis/disinformation spikes amid the unprecedented times of COVID-19 worldwide.