### PR TITLE
Update dz.csv

### DIFF
--- a/lists/dz.csv
+++ b/lists/dz.csv
@@ -460,3 +460,4 @@ https://ar.hibapress.com/,NEWS,News Media,2020-10-04,Netalitica,
 https://fr.hibapress.com/,NEWS,News Media,2020-10-04,Netalitica,
 https://sputnikarabic.ae/,NEWS,News Media,2023-04-24,test-lists.ooni.org contribution,
 https://arij.net/,NEWS,News Media,2023-08-09,test-lists.ooni.org contribution,Investigative journalism working accross Mena
+https://arabfcn.net/ ,NEWS,Media,2023-08-10,Saeedroy, is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region


### PR DESCRIPTION
Added AFCN website, The Arab Fact-Checkers Network (AFCN) is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region. This network is a product of the mis/disinformation spikes amid the unprecedented times of COVID-19 worldwide.