### PR TITLE
Update ps.csv

### DIFF
--- a/lists/ps.csv
+++ b/lists/ps.csv
@@ -548,3 +548,4 @@ https://www.zanzu.de/ar/,XED,Sex Education,2020-12-31,Netalitica,
 https://fustany.com/ar,XED,Sex Education,2020-12-31,Netalitica,
 https://stopsilencingpalestine.com/,POLR,Political Criticism,2021-06-10,Community member,
 https://arij.net/,NEWS,News Media,2023-08-09,test-lists.ooni.org contribution,Investigative journalism working accross Mena
+https://arabfcn.net/ ,NEWS,Media,2023-08-10,Saeedroy, is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region


### PR DESCRIPTION
Added AFCN website, The Arab Fact-Checkers Network (AFCN) is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region. This network is a product of the mis/disinformation spikes amid the unprecedented times of COVID-19 worldwide.