### PR TITLE
Update om.csv

### DIFF
--- a/lists/om.csv
+++ b/lists/om.csv
@@ -117,3 +117,4 @@ https://www.treegrab.com/sap/,ANON,Anonymization and circumvention tools,2014-04
 http://www.yahosein.com/,HUMR,Human Rights Issues,2014-04-15,citizenlab,
 https://sputnikarabic.ae/,NEWS,News Media,2023-04-24,test-lists.ooni.org contribution,
 https://arij.net/,NEWS,News Media,2023-08-09,test-lists.ooni.org contribution,Investigative journalism working accross Mena
+https://arabfcn.net/ ,NEWS,Media,2023-08-10,Saeedroy, is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region


### PR DESCRIPTION
Added AFCN website, The Arab Fact-Checkers Network (AFCN) is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region. This network is a product of the mis/disinformation spikes amid the unprecedented times of COVID-19 worldwide.