### PR TITLE
Update ae.csv

### DIFF
--- a/lists/ae.csv
+++ b/lists/ae.csv
@@ -726,3 +726,4 @@ https://dawnmena.org/,HUMR,Human Rights Issues,2022-12-07,rayasharbain,Organizat
 https://sputnikarabic.ae/,NEWS,News Media,2023-04-24,test-lists.ooni.org contribution,
 https://alhudood.net/,NEWS,News Media,2023-06-22,rayasharbain,arabic language sarcastic magazine seems to be blocked in Jordan
 https://arij.net/,NEWS,News Media,2023-08-09,test-lists.ooni.org contribution,Investigative journalism working accross Mena
+https://arabfcn.net/ ,NEWS,Media,2023-08-10,Saeedroy, is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region


### PR DESCRIPTION
Added AFCN website, The Arab Fact-Checkers Network (AFCN) is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region. This network is a product of the mis/disinformation spikes amid the unprecedented times of COVID-19 worldwide.