### PR TITLE
Update kw.csv

### DIFF
--- a/lists/kw.csv
+++ b/lists/kw.csv
@@ -567,3 +567,4 @@ http://www.zawagislamy.com/,DATE,Online Dating,2017-10-18,citizenlab,"""Islamic"
 https://upper-hand.org/,REL,Religion,2021-12-02,community member,
 https://sputnikarabic.ae/,NEWS,News Media,2023-04-24,test-lists.ooni.org contribution,
 https://arij.net/,NEWS,News Media,2023-08-09,test-lists.ooni.org contribution,Investigative journalism working accross Mena
+https://arabfcn.net/ ,NEWS,Media,2023-08-10,Saeedroy, is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region


### PR DESCRIPTION
Added AFCN website, The Arab Fact-Checkers Network (AFCN) is a grassroots network that works towards fostering transparent and impartial fact-checking in the Arab region. This network is a product of the mis/disinformation spikes amid the unprecedented times of COVID-19 worldwide.