### PR TITLE
Add Kashmir Walla’s website to India test list

### DIFF
--- a/lists/in.csv
+++ b/lists/in.csv
@@ -724,3 +724,4 @@ http://www.videolan.org/,MMED,Media sharing,2022-08-12,community member,VLC medi
 https://imap.sinarproject.org/,HUMR,Human Rights Issues,2023-03-24,sinarproject,
 https://hindi.sputniknews.in/,NEWS,News Media,2023-04-24,test-lists.ooni.org contribution,
 http://mirror.albony.xyz/,FILE,File-sharing,2023-06-28,test-lists.ooni.org contribution,
+https://thekashmirwalla.com/,NEWS,News Media,2023-08-22,community member,Kashmiri news site blocked in India


### PR DESCRIPTION
This news site was recently blocked in India: https://www.newslaundry.com/2023/08/21/this-opaque-censorship-is-gut-wrenching-the-kashmir-wallas-website-social-media-blocked-in-india