### PR TITLE
Re-add use-application-dns.net - explicit signal for DNS filtering

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1653,3 +1653,4 @@ https://pulse.internetsociety.org/,IGO,Intergovernmental Organizations,2023-07-0
 https://proxy.i2phides.me/,ANON,Anonymization and circumvention tools,2023-07-05,test-lists.ooni.org contribution,Popular I2P Inproxy
 https://www.y2mate.com/,MMED,Media sharing,2023-08-08,test-lists.ooni.org contribution,Youtube video download site
 http://cdns.grindr.com/,LGBT,LGBT,2023-08-09,test-lists.ooni.org contribution,one of the www.grindr.com endpoints
+http://use-application-dns.net/,ANON,Anonymization and circumvention tools,2023-09-01,David Fifield,NXDOMAIN indicates overt DNS filtering: https://support.mozilla.org/en-US/kb/canary-domain-use-application-dnsnet


### PR DESCRIPTION
With the news that [Firefox plans to start enabling ECH](https://groups.google.com/a/mozilla.org/g/dev-platform/c/uv7PNrHUagA/m/BNA4G8fOAAAJ) in the next releases, I wanted to suggest people check censorship measurements for [use-application-dns.net](https://support.mozilla.org/en-US/kb/canary-domain-use-application-dnsnet), because that canary domain is meant to disable DoH, and ECH depends on DoH.

use-application-dns.net had originally been added in #504 2019-09-19, but then it was deleted in #727 (a dead-domain check) on 2021-02-23.

Maybe prune-dead-urls.py was run on a network that reported NXDOMAIN for use-application-dns.net, since that is the signal that is supposed to signal DNS filtering is in place?