### PR TITLE
Add jabber.ru

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1684,3 +1684,4 @@ https://toolbox.googleapps.com/,HACK,Hacking Tools,2023-10-15,test-lists.ooni.or
 https://jw.org/,REL,Religion,2023-09-30,test-lists.ooni.org contribution,Official website of Jehovah's Witnesses
 https://kick.com/,MMED,Media sharing,2023-10-04,test-lists.ooni.org contribution,Gaming and livestreaming platform
 https://dlive.tv/,HOST,Hosting and Blogging Platforms,2023-10-04,test-lists.ooni.org contribution,Livestreaming platform
+https://www.jabber.ru/,COMT,Communication Tools,2023-10-31,Contributation over Git,"jabber.ru has been attacked, furthermore some ISPs block Russian sites"


### PR DESCRIPTION
jabber.ru was the victim of a MitM attack (see https://notes.valdikss.org.ru/jabber.ru-mitm/). Furthermore, some ISPs tend to block Russian sites (I know this from German universities, for example). I would therefore find it very interesting to see to what extent jabber.ru is also blocked.