### PR TITLE
Add reported blocks for GB

### DIFF
--- a/lists/gb.csv
+++ b/lists/gb.csv
@@ -2,3 +2,18 @@ url,category_code,category_description,date_added,source,notes
 https://en.wiktionary.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://pl.wikipedia.org/,CULTR,Culture,2018-07-06,Wikimedia,URLs provided by wikipedia based on the most popular language domains per country
 https://www.gov.uk/government/topical-events/coronavirus-covid-19-uk-government-response,PUBH,Public Health,2020-04-01,citizenlab,coronavirus
+https://fenopy.eu/,FILE,File-sharing,2023-11-05,wikipedia,Site reported to be blocked via BPI court order
+https://www.gomovies.tw/,MMED,Media sharing,2023-11-05,wikipedia,Site reported to be blocked via MPAA court order
+https://solarmovie.to/,MMED,Media sharing,2023-11-05,wikipedia,Site reported to be blocked via MPAA court order
+https://www.putlockers.do/,MMED,Media sharing,2023-11-05,wikipedia,Site reported to be blocked via MPAA court order
+https://putlocker.boo/,MMED,Media sharing,2023-11-05,wikipedia,Site reported to be blocked via MPAA court order
+https://softprober.com/,FILE,File-sharing,2023-11-05,wikipedia,Site reported to be blocked via MPAA court order
+https://123movies.info/,MMED,Media sharing,2023-11-05,wikipedia,Site reported to be blocked via MPAA court order
+https://ymovies.vip/,MMED,Media sharing,2023-11-05,wikipedia,Site reported to be blocked via MPAA court order
+https://1hd.to/,MMED,Media sharing,2023-11-05,wikiepdia,Site reported to be blocked via MPAA court order
+https://tinyzonetv.se/,MMED,Media sharing,2023-11-05,wikipedia,Site reported to be blocked via MPAA court order
+https://tvshows88.live/,MMED,Media sharing,2023-11-05,wikipedia,Site reported to be blocked via MPAA court order
+https://nswrom.com/,FILE,File-sharing,2023-11-05,wikipedia,Site reported to be blocked via Nintendo court order
+https://nitroflare.com/,FILE,File-sharing,2023-11-05,wikipedia,Site reported to be blocked via BPI court order
+https://rossiyasegodnya.com/,NEWS,News Media,2023-11-05,451unavailable,Blocked by UK sanctions
+https://sanctioned-suicide.org/,PUBH,Public Health,2023-11-05,wikipedia,Site reported to be blocked


### PR DESCRIPTION
Adds some of the more recent blocks from https://wiki.451unavailable.org.uk/wiki/Main_Page and https://en.wikipedia.org/wiki/List_of_websites_blocked_in_the_United_Kingdom as well as recent news coverage