### PR TITLE
Add check for invalid header

### DIFF
--- a/lists/kz.csv
+++ b/lists/kz.csv
@@ -1,3 +1,4 @@
+url,category_code,category_description,date_added,source,notes
 http://www.akorda.kz/,CULTR,Culture,2014-04-15,citizenlab,
 http://www.dumaem.ru/,CULTR,Culture,2014-04-15,citizenlab,
 http://www.kazbio.info/,CULTR,Culture,2014-04-15,citizenlab,

--- a/scripts/lint-lists.py
+++ b/scripts/lint-lists.py
@@ -65,7 +65,7 @@ class TestListErrorWithValue(TestListError):
         print(msg)
 
 class InvalidHeader(TestListError):
-    name = 'Invalid Column Number'
+    name = 'Invalid Header'
 
 class InvalidColumnNumber(TestListError):
     name = 'Invalid Column Number'

--- a/scripts/lint-lists.py
+++ b/scripts/lint-lists.py
@@ -64,6 +64,9 @@ class TestListErrorWithValue(TestListError):
             msg += ' ({})'.format(self.details)
         print(msg)
 
+class InvalidHeader(TestListError):
+    name = 'Invalid Column Number'
+
 class InvalidColumnNumber(TestListError):
     name = 'Invalid Column Number'
 
@@ -149,7 +152,11 @@ def main(lists_path, fix_duplicates=False, fix_slash=False):
             continue
         with open(csv_path, 'r', encoding='utf-8') as in_file:
             reader = csv.reader(in_file, delimiter=',')
-            next(reader) # skip header
+            first_line = next(reader)
+            if first_line != header:
+                errors.append(
+                    InvalidHeader(csv_path, 0)
+                )
             urls_bag = set()
             errors = []
             rows = []


### PR DESCRIPTION
This adds a check for an invalid header and fixes that KZ list which was malformed since: https://github.com/citizenlab/test-lists/commit/e96c7169fe147419e6e0d40ed92ae7fc90ababb1