### PR TITLE
Update th.csv

### DIFF
--- a/lists/th.csv
+++ b/lists/th.csv
@@ -56,7 +56,7 @@ http://www.thailandvoice.com/,NEWS,News Media,2014-04-15,citizenlab,Links to blo
 https://vimeo.com/prachatai/,NEWS,News Media,2014-04-15,citizenlab,Vimeo channel of Prachatai online news
 https://www.voicetv.co.th/,NEWS,News Media,2014-04-15,citizenlab,Voice TV news channel (free-to-air terrestrial TV) [th]
 https://alliance4democracy.blogspot.com/,POLR,Political Criticism,2014-04-15,citizenlab,"News clip about the People's Alliance for Democracy, a political movement from 2005-2006. Content mostly in English. Most recent update: 3 Mar 2006 (as of May 2020). [en]"
-http://www.bhumjaithai.com/,POLR,Political Criticism,2014-04-15,citizenlab,"Bhumjaithai Party (Phumchai Thai Party), part of ruling party (for the cabinet sworn on 16 July 2019)"
+https://www.bhumjaithai.com/,POLR,Political Criticism,2014-04-15,citizenlab,"Bhumjaithai Party (Phumchai Thai Party), part of ruling party (for the cabinet sworn on 16 July 2019)"
 https://www.democrat.or.th/,POLR,Political Criticism,2014-04-15,citizenlab,"Democrat Party, a major political party [th]"
 http://www.uddtoday.blogspot.com/,POLR,Political Criticism,2014-04-15,citizenlab,"UDD Today blog. (UDD - United Front for Democracy Against Dictatorship, a fraction of Red Shirts) [th]"
 http://www.thaichix.com/,PORN,Pornography,2014-04-15,citizenlab,"Asian porn. Found blocked in 2014, see: https://citizenlab.ca/2014/07/information-controls-thailand-2014-coup/ [en]"
@@ -91,7 +91,7 @@ https://www.unescap.org/,IGO,Intergovernmental Organizations,2014-04-15,citizenl
 http://thaiopensource.org/,CULTR,Culture,2014-04-15,citizenlab,ThaiOpenSource. Open source software and hardwre development blog. [th]
 http://www.manager.co.th/,NEWS,News Media,2014-04-15,citizenlab,
 http://www.ftawatch.org/,POLR,Political Criticism,2014-04-15,citizenlab,"FTA Watch, a civil society network on free trade agreements [th]"
-https://redsiam.wordpress.com/,POLR,Political Criticism,2014-04-15,citizenlab,"A blog of Giles Ji Ungpakorn, a Marxist political activist and a former political science lecturer in Thailand. Fled to the UK in 2009 after facing a lèse majesté charge in Thailand. [en]"
+https://redsiam.wordpress.com/,POLR,Political Criticism,2014-04-15,citizenlab,"A blog of Giles Ji Ungpakorn, a Marxist political activist and a former political science lecturer in Thailand. Fled to the UK in 2009 after facing a lèse majesté charge in Thailand. (All the content has been removed - as of 23 Dec 2023) [en]"
 https://sameskybooks.net/,POLR,Political Criticism,2014-04-15,citizenlab,Same Sky Books publishing - critical publications about Thai politics [th]
 http://www.catholic.or.th/,REL,Religion,2014-04-15,citizenlab,Bangkok Archdiocese [th]
 http://www.cct.or.th/,REL,Religion,2014-04-15,citizenlab,Church of Christ in Thailand [th]
@@ -149,10 +149,9 @@ http://yalepress.yale.edu/yupbooks/book.asp?isbn=0300106823/,POLR,Political Crit
 http://thaicherry.com/,PORN,Pornography,2014-04-15,citizenlab,Porn
 http://thaigirls.net/,PORN,Pornography,2014-04-15,citizenlab,
 http://tsthai.com/,PORN,Pornography,2014-04-15,citizenlab,
-http://www.avert.org/aidsthai.htm/,PUBH,Public Health,2014-04-15,citizenlab,Information about HIV and AIDS in Thailand [en]
+http://www.avert.org/aidsthai.htm/,PUBH,Public Health,2014-04-15,"citizenlab,Information about HIV and AIDS in Thailand (Redirected to https://www.beintheknow.org/understanding-hiv-epidemic/data - as of 23 Dec 2023) [en]"
 http://www.cfan.org/,REL,Religion,2014-04-15,citizenlab,Christ for all Nations. Old URL. [en]
-http://enlawfoundation.org/,ENV,Environment,2016-09-20,unknown,Environmental litigation and advocacy [th] [en]
-http://www.cabinet.soc.go.th/,GOVT,Government,2016-09-20,unknown,The Secretariat of the Cabinet [th]
+https://enlawfoundation.org/,ENV,Environment,2016-09-20,unknown,Environmental litigation and advocacy [th] [en]
 https://www.ect.go.th/,GOVT,Government,2016-09-20,unknown,Election Commission of Thailand [th] [en]
 https://www.parliament.go.th/,GOVT,Government,2016-09-20,unknown,"Parliament of Thailand. After the 2014 Coup until 2019, it is home of National Reform Steering Assembly. [th] [en]"
 http://www.rtarf.mi.th/,GOVT,Government,2016-09-20,unknown,Royal Thai Armed Forces HQ [th]
@@ -178,7 +177,7 @@ https://www.khaosodenglish.com/,NEWS,News Media,2016-09-20,unknown,Khao Sod news
 https://www.telecomasia.net/,NEWS,News Media,2016-09-20,unknown,"Telecom Asia, also cover ICT news in Asia. Announced closure on 2019-05-31. No longer updated. [en]"
 https://th.wikipedia.org/,NEWS,News Media,2016-09-20,unknown,Thai Wikipedia (HTTPS) [th]
 https://thaipublica.org/,NEWS,News Media,2016-09-20,unknown,"Thai online newspaper, with focus on transparency, good governance of government and business, social innovation [th]"
-https://www.thaivisa.com/,NEWS,News Media,2016-09-20,unknown,Expat news. Now part of The Nation. [en]
+https://www.thaivisa.com/,NEWS,News Media,2016-09-20,unknown,"Expat news. Now redirected to https://aseannow.com/ [en]"
 https://www.tnews.co.th/,NEWS,News Media,2016-09-20,unknown,"News agency, right wing. [th]"
 http://2bangkok.com/,POLR,Political Criticism,2016-09-20,unknown,"Thai political analysis, underreported news, and Bangkok public transportation. As of May 2020, the blog focuses on the analysis of political cartoons from Thai newspaper. [en]"
 https://www.asiasentinel.com/,NEWS,News Media,2016-09-20,unknown,Asian politics review and analysis [en]

--- a/lists/th.csv
+++ b/lists/th.csv
@@ -149,7 +149,7 @@ http://yalepress.yale.edu/yupbooks/book.asp?isbn=0300106823/,POLR,Political Crit
 http://thaicherry.com/,PORN,Pornography,2014-04-15,citizenlab,Porn
 http://thaigirls.net/,PORN,Pornography,2014-04-15,citizenlab,
 http://tsthai.com/,PORN,Pornography,2014-04-15,citizenlab,
-http://www.avert.org/aidsthai.htm/,PUBH,Public Health,2014-04-15,"citizenlab,Information about HIV and AIDS in Thailand (Redirected to https://www.beintheknow.org/understanding-hiv-epidemic/data - as of 23 Dec 2023) [en]"
+http://www.avert.org/aidsthai.htm/,PUBH,Public Health,2014-04-15,citizenlab,"Information about HIV and AIDS in Thailand (Redirected to https://www.beintheknow.org/understanding-hiv-epidemic/data - as of 23 Dec 2023) [en]"
 http://www.cfan.org/,REL,Religion,2014-04-15,citizenlab,Christ for all Nations. Old URL. [en]
 https://enlawfoundation.org/,ENV,Environment,2016-09-20,unknown,Environmental litigation and advocacy [th] [en]
 https://www.ect.go.th/,GOVT,Government,2016-09-20,unknown,Election Commission of Thailand [th] [en]

--- a/lists/th.csv
+++ b/lists/th.csv
@@ -10,13 +10,11 @@ https://www.greenpeace.org/thailand/,ENV,Environment,2014-04-15,citizenlab,Green
 https://sathai.org/,ENV,Environment,2014-04-15,citizenlab,Sustainable Agriculture Foundation [th]
 https://www.seub.or.th/,ENV,Environment,2014-04-15,citizenlab,Seub Nakhasathien Foundation. One of the most prominent environment NGOs. Protection of forest. [th]
 https://www.tei.or.th/,ENV,Environment,2014-04-15,citizenlab,"Thai Environment Institute, a think tank [th] [en]"
-https://www.tei.or.th/tbcsd/,ENV,Environment,2014-04-15,citizenlab,Thai Business Council for Sustainable Development [th]
 http://www.activeodds.com/,GMB,Gambling,2014-04-15,citizenlab,A sport betting site [en]
 https://www.betbrain.com/,GMB,Gambling,2014-04-15,citizenlab,A sport betting site [en]
 https://www.betdaq.com/,GMB,Gambling,2014-04-15,citizenlab,"A gambling and betting site, registred in Gibraltar. Operated by LC International Limited. [en]"
 https://www.bethelp.com/,GMB,Gambling,2014-04-15,citizenlab,A sport betting site. Owned and Operated by Asian Handicap. [en]
 https://pantip.com/,GRP,Social Networking,2014-04-15,citizenlab,Most popular online forum in Thailand. Upgraded to HTTPS in 2017.
-http://pantip.com/forum/rajdumnern/,GRP,Social Networking,2014-04-15,citizenlab,A section for political discussion in the most popular online forum in Thailand
 http://www.prachatalk.com/,GRP,Social Networking,2014-04-15,citizenlab,Web forum. Active in political topics but also include other topics like travel. [th]
 http://www.teenee.com/,GRP,Social Networking,2014-04-15,citizenlab,News and entertainment portal. Among top visited site in the country. [th]
 https://www.hostpacific.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,"HostPacific.com hosting service by Smile Interactive Co., Ltd. [th]"
@@ -39,7 +37,6 @@ http://www.bangkokrainbow.org/,LGBT,LGBT,2014-04-15,citizenlab,"Bangkok Rainbow 
 https://www.fridae.asia/,LGBT,LGBT,2014-04-15,citizenlab,Fridae - connecting gay Asia [en] [zh]
 http://www.gthai.net/,LGBT,LGBT,2014-04-15,citizenlab,Thailand's gay portal
 https://www.utopia-asia.com/,LGBT,LGBT,2014-04-15,citizenlab,Asian gay and lesbian resource [en]
-https://www.utopia-asia.com/tipsthai.htm,LGBT,LGBT,2014-04-15,citizenlab,Information for LGBT in Thailand [en]
 http://www.thaicounsel.com/,CULTR,Culture,2014-04-15,citizenlab,Professional training. Run by Psychology Hotline Institute. [th]
 http://www.flickr.com/people/prachatai/,MMED,Media sharing,2014-04-15,citizenlab,Flickr account of Prachatai newspapers
 http://www.asianpacificpost.com/,NEWS,News Media,2014-04-15,citizenlab,Asian Pacific Post [en]
@@ -81,7 +78,6 @@ https://www.halalthailand.com/,CULTR,Culture,2014-04-15,citizenlab,"News and dir
 https://www.iias.asia/,CULTR,Culture,2014-04-15,citizenlab,International Institute for Asian Studies
 https://gamecenter.kapook.com/,GAME,Gaming,2014-04-15,citizenlab,Online casual games
 https://www.obec.go.th/,GOVT,Government,2014-04-15,citizenlab,Office of the Basic Education Commission (OBEC)
-http://www.pantip.com/,GRP,Social Networking,2014-04-15,citizenlab,Most popular online forum in Thailand.
 https://www.thailandfriends.com/,GRP,Social Networking,2014-04-15,citizenlab,ThailandFriends web forum [en]
 http://www.mekonginfo.org/,IGO,Intergovernmental Organizations,2014-04-15,citizenlab,Mekong River Commission - Data and Information Services [en]
 http://www.mrcmekong.org/,IGO,Intergovernmental Organizations,2014-04-15,citizenlab,Mekong River Commission [en]
@@ -144,11 +140,6 @@ http://www.amazon.co.uk/exec/obidos/ASIN/0300106823/203-4157180-0680751#product-
 https://downmerng.blogspot.com/,POLR,Political Criticism,2014-04-15,citizenlab,"Anti-coup and anti-establishment blog. Most recent update: 14 Dec 2012 (as of May 2020). Its HTTP URL found blocked in 2014, see: https://citizenlab.ca/2014/07/information-controls-thailand-2014-coup/ [th]"
 https://www.ptp.or.th/,POLR,Political Criticism,2014-04-15,citizenlab,"Pheu Thai Party, a major political party (an opposition party - for the cabinet sworn on 16 July 2019)"
 http://yalepress.yale.edu/yupbooks/book.asp?isbn=0300106823/,POLR,Political Criticism,2014-04-15,citizenlab,"The King Never Smiles: A Biography of Thailand's Bhumibol Adulyadej (2006), banned for importation to Thailand. (As of June 2020, the link at Yale University Press from 2006 is no longer valid.)"
-http://thaicherry.com/,PORN,Pornography,2014-04-15,citizenlab,Porn
-http://thaigirls.net/,PORN,Pornography,2014-04-15,citizenlab,
-http://tsthai.com/,PORN,Pornography,2014-04-15,citizenlab,
-http://www.avert.org/aidsthai.htm/,PUBH,Public Health,2014-04-15,citizenlab,"Information about HIV and AIDS in Thailand (Redirected to https://www.beintheknow.org/understanding-hiv-epidemic/data - as of 23 Dec 2023) [en]"
-http://www.cfan.org/,REL,Religion,2014-04-15,citizenlab,Christ for all Nations. Old URL. [en]
 https://enlawfoundation.org/,ENV,Environment,2016-09-20,unknown,Environmental litigation and advocacy [th] [en]
 https://www.ect.go.th/,GOVT,Government,2016-09-20,unknown,Election Commission of Thailand [th] [en]
 https://www.parliament.go.th/,GOVT,Government,2016-09-20,unknown,"Parliament of Thailand. After the 2014 Coup until 2019, it is home of National Reform Steering Assembly. [th] [en]"

--- a/lists/th.csv
+++ b/lists/th.csv
@@ -1,9 +1,7 @@
 url,category_code,category_description,date_added,source,notes
 http://www.14tula.com/,CULTR,Culture,2014-04-15,citizenlab,14 October 1973 memorial (for 14 October B.E. 2516 demonstration) [th]
-https://www.asiasoft.net/,CULTR,Culture,2014-04-15,citizenlab,"Asia Soft, a computer games developer [en]"
 https://www.baanrak.com/,DATE,Online Dating,2014-04-15,citizenlab,"Dating, horoscope [th]"
 http://www.dateinasia.com/,DATE,Online Dating,2014-04-15,citizenlab,Date in Asia. A dating site. [en]
-http://www.thailove.com/,DATE,Online Dating,2014-04-15,citizenlab,Thai Dating website - in English language [en]
 http://www.tff.or.th/,ECON,Economics,2014-04-15,citizenlab,"Thai Fund Foundation, supports works of local and regional civil society groups"
 https://adeq.or.th/,ENV,Environment,2014-04-15,citizenlab,Association for the Development of Environmental Quality [th]
 https://biothai.net/,ENV,Environment,2014-04-15,citizenlab,"Biodiversity, sustainable agriculture, food sovereignty group [th] [en]"
@@ -41,7 +39,7 @@ http://www.bangkokrainbow.org/,LGBT,LGBT,2014-04-15,citizenlab,"Bangkok Rainbow 
 https://www.fridae.asia/,LGBT,LGBT,2014-04-15,citizenlab,Fridae - connecting gay Asia [en] [zh]
 http://www.gthai.net/,LGBT,LGBT,2014-04-15,citizenlab,Thailand's gay portal
 https://www.utopia-asia.com/,LGBT,LGBT,2014-04-15,citizenlab,Asian gay and lesbian resource [en]
-https://www.utopia-asia.com/tipsthai.htm/,LGBT,LGBT,2014-04-15,citizenlab,Information for LGBT in Thailand [en]
+https://www.utopia-asia.com/tipsthai.htm,LGBT,LGBT,2014-04-15,citizenlab,Information for LGBT in Thailand [en]
 http://www.thaicounsel.com/,CULTR,Culture,2014-04-15,citizenlab,Professional training. Run by Psychology Hotline Institute. [th]
 http://www.flickr.com/people/prachatai/,MMED,Media sharing,2014-04-15,citizenlab,Flickr account of Prachatai newspapers
 http://www.asianpacificpost.com/,NEWS,News Media,2014-04-15,citizenlab,Asian Pacific Post [en]

--- a/lists/th.csv
+++ b/lists/th.csv
@@ -5,21 +5,20 @@ https://www.baanrak.com/,DATE,Online Dating,2014-04-15,citizenlab,"Dating, horos
 http://www.dateinasia.com/,DATE,Online Dating,2014-04-15,citizenlab,Date in Asia. A dating site. [en]
 http://www.thailove.com/,DATE,Online Dating,2014-04-15,citizenlab,Thai Dating website - in English language [en]
 http://www.tff.or.th/,ECON,Economics,2014-04-15,citizenlab,"Thai Fund Foundation, supports works of local and regional civil society groups"
-http://www.adeq.or.th/,ENV,Environment,2014-04-15,citizenlab,Association for the Development of Environmental Quality [th]
+https://adeq.or.th/,ENV,Environment,2014-04-15,citizenlab,Association for the Development of Environmental Quality [th]
 https://biothai.net/,ENV,Environment,2014-04-15,citizenlab,"Biodiversity, sustainable agriculture, food sovereignty group [th] [en]"
 http://www.ecologyasia.com/,ENV,Environment,2014-04-15,citizenlab,Wildlife information in Souteast Asia - in English [en]
 https://www.greenpeace.org/thailand/,ENV,Environment,2014-04-15,citizenlab,Greenpeace Thailand. Environment international NGO. [th]
-http://sathai.org/,ENV,Environment,2014-04-15,citizenlab,Sustainable Agriculture Foundation [th]
+https://sathai.org/,ENV,Environment,2014-04-15,citizenlab,Sustainable Agriculture Foundation [th]
 https://www.seub.or.th/,ENV,Environment,2014-04-15,citizenlab,Seub Nakhasathien Foundation. One of the most prominent environment NGOs. Protection of forest. [th]
-http://www.tei.or.th/,ENV,Environment,2014-04-15,citizenlab,"Thai Environment Institute, a think tank [th] [en]"
-http://www.tei.or.th/tbcsd/,ENV,Environment,2014-04-15,citizenlab,Thai Business Council for Sustainable Development [th]
-http://www.thungyai.org/,ENV,Environment,2014-04-15,citizenlab,Foundation of Western Forest Complex Conservation [th]
+https://www.tei.or.th/,ENV,Environment,2014-04-15,citizenlab,"Thai Environment Institute, a think tank [th] [en]"
+https://www.tei.or.th/tbcsd/,ENV,Environment,2014-04-15,citizenlab,Thai Business Council for Sustainable Development [th]
 http://www.activeodds.com/,GMB,Gambling,2014-04-15,citizenlab,A sport betting site [en]
 https://www.betbrain.com/,GMB,Gambling,2014-04-15,citizenlab,A sport betting site [en]
 https://www.betdaq.com/,GMB,Gambling,2014-04-15,citizenlab,"A gambling and betting site, registred in Gibraltar. Operated by LC International Limited. [en]"
 https://www.bethelp.com/,GMB,Gambling,2014-04-15,citizenlab,A sport betting site. Owned and Operated by Asian Handicap. [en]
 https://pantip.com/,GRP,Social Networking,2014-04-15,citizenlab,Most popular online forum in Thailand. Upgraded to HTTPS in 2017.
-https://pantip.com/forum/rajdumnern/,GRP,Social Networking,2014-04-15,citizenlab,A section for political discussion in the most popular online forum in Thailand
+http://pantip.com/forum/rajdumnern/,GRP,Social Networking,2014-04-15,citizenlab,A section for political discussion in the most popular online forum in Thailand
 http://www.prachatalk.com/,GRP,Social Networking,2014-04-15,citizenlab,Web forum. Active in political topics but also include other topics like travel. [th]
 http://www.teenee.com/,GRP,Social Networking,2014-04-15,citizenlab,News and entertainment portal. Among top visited site in the country. [th]
 https://www.hostpacific.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,"HostPacific.com hosting service by Smile Interactive Co., Ltd. [th]"
@@ -44,7 +43,6 @@ http://www.gthai.net/,LGBT,LGBT,2014-04-15,citizenlab,Thailand's gay portal
 https://www.utopia-asia.com/,LGBT,LGBT,2014-04-15,citizenlab,Asian gay and lesbian resource [en]
 https://www.utopia-asia.com/tipsthai.htm/,LGBT,LGBT,2014-04-15,citizenlab,Information for LGBT in Thailand [en]
 http://www.thaicounsel.com/,CULTR,Culture,2014-04-15,citizenlab,Professional training. Run by Psychology Hotline Institute. [th]
-http://upload.prachatalk.com/,MMED,Media sharing,2014-04-15,citizenlab,Upload section of Prachatalk web forum (login required) [th]
 http://www.flickr.com/people/prachatai/,MMED,Media sharing,2014-04-15,citizenlab,Flickr account of Prachatai newspapers
 http://www.asianpacificpost.com/,NEWS,News Media,2014-04-15,citizenlab,Asian Pacific Post [en]
 http://www.asiantribune.com/,NEWS,News Media,2014-04-15,citizenlab,Asian Tribute [en]
@@ -97,10 +95,8 @@ https://redsiam.wordpress.com/,POLR,Political Criticism,2014-04-15,citizenlab,"A
 https://sameskybooks.net/,POLR,Political Criticism,2014-04-15,citizenlab,Same Sky Books publishing - critical publications about Thai politics [th]
 http://www.catholic.or.th/,REL,Religion,2014-04-15,citizenlab,Bangkok Archdiocese [th]
 http://www.cct.or.th/,REL,Religion,2014-04-15,citizenlab,Church of Christ in Thailand [th]
-https://pantip.com/forum/rajdumnern,GRP,Social Networking,2014-04-15,citizenlab,A political section in a web discussion forum [th]
 http://weareallhuman2.info/,GRP,Social Networking,2014-04-15,citizenlab,"Blocked by Facebook (cannot be posted on the platform, as of 2020-03-15)"
 https://www.thaiware.com/,NEWS,News Media,2014-04-15,citizenlab,"IT news, software review, and software download site [th]"
-https://www.bbc.com/news/world/asia_pacific,NEWS,News Media,2014-04-15,citizenlab,BBC News Asia Pacific [en]
 https://www.dedbit.com/,FILE,File-sharing,2014-04-15,citizenlab,File-sharing site. Member only. Includes porn. [th]
 https://www.pinnacle.com/,GMB,Gambling,2014-04-15,citizenlab,"A sport betting, games, and casino site, registered in Curaçao [en]"
 https://sports.gamebookers.com/en/sports/,GMB,Gambling,2014-04-15,citizenlab,"A sport betting site, registered in Gibraltar. [en]"
@@ -211,7 +207,6 @@ http://th.wikipedia.org/wiki/%E0%B8%AA%E0%B8%A1%E0%B9%80%E0%B8%94%E0%B9%87%E0%B8
 http://th.wikipedia.org/wiki/%E0%B8%AA%E0%B8%A2%E0%B8%B2%E0%B8%A1%E0%B8%A1%E0%B8%81%E0%B8%B8%E0%B8%8E%E0%B8%A3%E0%B8%B2%E0%B8%8A%E0%B8%81%E0%B8%B8%E0%B8%A1%E0%B8%B2%E0%B8%A3,NEWS,News Media,2016-09-20,unknown,Crown Prince of Thailand [th]
 https://landdestroyer.blogspot.com/,POLR,Political Criticism,2016-11-17,citizenlab,"The Land Destroyer Report, a political analysis blog by Tony Cartalucci (very likely a pseudonym). Some content also available in Thai, Arabic, and Russian. Occastionally make false claims against democracy movements. The site expands from Thailand and Asia to cover Middle East and other parts of the world as well. Thailand is still in one of its main themes, as shown in the main menu at the top of the site. Same author also run http://altthainews.blogspot.com/ [en]"
 https://landdestroyer.blogspot.com/search/label/Thailand/,POLR,Political Criticism,2016-11-17,citizenlab,Thailand category page for The Land Destroyer Report [en]
-https://www.bbc.com/thai/,NEWS,News Media,2016-12-08,sinarproject,BBC Thai language sub-site [th]
 http://www.bbc.com/thai/thailand-38173269/,NEWS,News Media,2016-12-08,sinarproject,BBC King Maha Vajiralongkorn profile page in Thai [th]
 https://www.soimilk.com/,CULTR,Culture,2017-01-19,unknown,"Lifestyle and events, in English language [en]"
 https://www.cia.gov/library/readingroom/collection/crest-25-year-program-archive/,GOVT,Government,2017-01-19,unknown,"CIA 25-Year Program Archive, with records from Bangkok Bureau"
@@ -289,7 +284,6 @@ https://www.lnwshop.com/,COMM,E-commerce,2020-05-31,netalitica,E-commerce platfo
 https://www.powerbuy.co.th/,COMM,E-commerce,2020-05-31,netalitica,"Electronics, home appliances"
 https://www.robinson.co.th/,COMM,E-commerce,2020-05-31,netalitica,Online department store
 https://shopee.co.th/,COMM,E-commerce,2020-05-31,netalitica,E-commerce platform
-https://shoponline.tescolotus.com/groceries/,COMM,E-commerce,2020-05-31,netalitica,"Supermarket, groceries"
 https://www.tops.co.th/th/,COMM,E-commerce,2020-05-31,netalitica,Supermarket
 https://www.watsons.co.th/,COMM,E-commerce,2020-05-31,netalitica,Personal care and cosmetics
 https://www.037hdmovie.com/,CULTR,Culture,2020-05-31,netalitica,Watch movie online [th]


### PR DESCRIPTION
Update to HTTPS version, according to current usage of the website (no blocking record of any version, either HTTPS or HTTP)
- http://www.adeq.or.th/ -> https://adeq.or.th/ 
- http://sathai.org/ -> https://sathai.org/
- http://www.tei.or.th/ -> https://www.tei.or.th/
- http://www.bhumjaithai.com/ -> https://www.bhumjaithai.com/

Remove HTTPS version of a domain with a path, as they can't be properly checked
- https://www.bbc.com/thai/

Remove old pages that can longer be found
- https://www.bbc.com/news/world/asia_pacific (change in website structure)
- https://shoponline.tescolotus.com/groceries/ (no longer in business under this name)
- http://www.thungyai.org/ (redirected to gambling site)
- http://upload.prachatalk.com/ (domain name is expired)
- http://www.cabinet.soc.go.th/ (no longer exist, change in government website structure)
- https://www.asiasoft.net/ (redirected to new domain: https://www.asphere.co/, no history of censorship previously, not significant)
- http://www.thailove.com/ (no longer in operation, a park domain now, no history of censorship)

Remove duplicated
- https://pantip.com/forum/rajdumnern

Add info about redirection / site activity
- https://www.thaivisa.com
- https://redsiam.wordpress.com/
- http://www.avert.org/aidsthai.htm/

Edit
- https://www.utopia-asia.com/tipsthai.htm/ -> https://www.utopia-asia.com/tipsthai.htm (Remove trailing slash, the URL with trailing slash is 404)
