### PR TITLE
Removed http://www.solicitorsfromhell.com/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -807,7 +807,6 @@ http://www.slideshare.net/,MMED,Media sharing,2014-04-15,citizenlab,Updated by O
 http://www.slotland.com/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.slsknet.org/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.socom.mil/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.solicitorsfromhell.com/,HATE,Hate Speech,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.sos-reporters.net/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.southcom.mil/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.spark.com/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Dead link. Last known active: https://web.archive.org/web/20221128122611/http://solicitorsfromhell.com/