### PR TITLE
Removed http://www.jewwatch.com/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -589,7 +589,6 @@ https://www.iucn.org/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2
 http://www.jackdaniels.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.jdate.com/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.jesussaves.cc/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.jewwatch.com/,HATE,Hate Speech,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.jhr.ca/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.jihadwatch.org/,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.jmarshall.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Focus changeover. No known new/alternative website
https://web.archive.org/web/20221014224711/https://www.jewwatch.com/