### PR TITLE
Removed http://www.harkatulmujahideen.org/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -511,7 +511,6 @@ http://www.hackforums.net/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by O
 http://www.hackhull.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.hacktivismo.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.hanes.com/,PROV,Provocative Attire,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.harkatulmujahideen.org/,MILX,Terrorism and Militants,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.helvetas.ch/,ECON,Economics,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.herdict.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.heritage.org/,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Dead link. No known new or alternative website.