### PR TITLE
Removed http://earth-liberation-front.org/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -67,7 +67,6 @@ https://docs.google.com/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI
 https://download.cnet.com/Freegate/3000-2085_4-10415391.html,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://drugs-forum.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://duckduckgo.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://earth-liberation-front.org/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://ebuddy.com/,GRP,Social Networking,2014-04-15,citizenlab,"Updated on 2022-02-21, website under construction"
 https://www.emailaddresses.com/,HOST,Hosting and Blogging Platforms,2014-04-15,citizenlab,Updated on 2022-02-21
 https://emchurch.org/,REL,Religion,2014-04-15,citizenlab,Updated on 2022-02-21


### PR DESCRIPTION
Focus changeover

Start-2013: https://web.archive.org/web/20130601054453/http://earth-liberation-front.org/

2014-2015: https://web.archive.org/web/20131204020900/http://earth-liberation-front.org/

2015-2016: https://web.archive.org/web/20150910004857/http://earth-liberation-front.org/

2016-2018: https://web.archive.org/web/20161220045654/http://earth-liberation-front.org/

2018-2020: https://web.archive.org/web/20181109004509/http://earth-liberation-front.org/

2020-Present: https://web.archive.org/web/20200923171836/http://earth-liberation-front.org/