### PR TITLE
Removed http://comohacerseunaborto.com/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1090,7 +1090,6 @@ https://www.ifc.org/,ECON,Economics,2019-09-25,OONI,
 http://www.ibe.unesco.org/,IGO,Intergovernmental Organizations,2019-09-25,OONI,
 https://www.iaea.org/,ENV,Environment,2019-09-25,OONI,
 https://www.aljazeera.com/,NEWS,News Media,2019-09-19,OONI,
-http://comohacerseunaborto.com/,XED,Sex Education,2019-10-17,OONI,Abortion site for Latin America
 https://en.wikipedia.org/wiki/List_of_LGBT_awareness_periods,LGBT,LGBT,2019-11-18,OutRight International,
 https://www.ohchr.org/en/issues/sexualorientationgender/pages/index.aspx,LGBT,LGBT,2019-11-18,OutRight International,
 https://en.wikipedia.org/wiki/Sex_and_gender_distinction,LGBT,LGBT,2019-11-18,OutRight International,


### PR DESCRIPTION
comohacerseunaborto.com is parked free, courtesy of GoDaddy.com
![image](https://github.com/citizenlab/test-lists/assets/92066373/412179a6-6ba0-4ad9-bc37-20c1e7c8076c)