### PR TITLE
Removed http://www.thehacktivist.com/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -832,7 +832,6 @@ http://www.theepochtimes.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by O
 http://www.theglobalfund.org/,PUBH,Public Health,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.thegooddrugsguide.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.theguardian.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.thehacktivist.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.themwl.org/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.theonion.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.theregister.co.uk/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Last known active: http://web.archive.org/web/20090429065456/http://www.thehacktivist.com/