### PR TITLE
Removed http://www.securitytracker.com/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -788,7 +788,6 @@ https://www.search.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OON
 http://www.searchindia.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.securenym.net/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.securityfocus.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.securitytracker.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.secfirst.org/,HUMR,Human Rights Issues,2017-11-09,securityfirst,
 https://www.sendspace.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.sendthisfile.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
securitytracker.com is parked free, courtesy of GoDaddy.com
![image](https://github.com/citizenlab/test-lists/assets/92066373/f2f6b02e-c62b-40e5-b66c-083f8e695bd7)