### PR TITLE
Removed http://www.metacafe.com/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -641,7 +641,6 @@ http://www.medecinsdumonde.org/,PUBH,Public Health,2014-04-15,citizenlab,Updated
 https://www.mediafire.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.medicinenet.com/,PUBH,Public Health,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.megaproxy.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.metacafe.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.metacrawler.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.metal-archives.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.microsofttranslator.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Dead link. Its alternative website: http://videoshub.com/, is also not working.
https://en.wikipedia.org/wiki/Metacafe