### PR TITLE
Removed http://www.sos-reporters.net/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -808,7 +808,6 @@ http://www.slotland.com/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2
 http://www.slsknet.org/,FILE,File-sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.socom.mil/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.solicitorsfromhell.com/,HATE,Hate Speech,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.sos-reporters.net/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.southcom.mil/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.spark.com/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.speeddater.co.uk/,DATE,Online Dating,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Last known active: https://web.archive.org/web/20161103005652/http://www.sos-reporters.net/
![image](https://github.com/citizenlab/test-lists/assets/92066373/fd7ec0a5-2c2e-4367-b9bb-1bbe025508b4)