### PR TITLE
Removed http://www.pdhre.org/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -716,7 +716,6 @@ https://www.paypal.com/,COMM,E-commerce,2014-04-15,citizenlab,Updated by OONI on
 http://www.pc2call.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.pcgamer.com/,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.pcusa.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.pdhre.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.peacefire.org/circumventor/simple-circumventor-instructions.html,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.people.com.cn/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.peta.org/,ENV,Environment,2014-04-15,citizenlab,Updated by OONI on 2017-02-14

--- a/lists/id.csv
+++ b/lists/id.csv
@@ -24,6 +24,7 @@ http://www.faithfreedom.org/,REL,Religion,2014-04-15,citizenlab,
 https://groups.google.com/group/free-proxy-list-update-daily?pli=1/,COMT,Communication Tools,2014-04-15,citizenlab,
 https://indonbodoh.blogspot.com/,HATE,Hate Speech,2014-04-15,citizenlab,
 https://anonymousproxylist.net/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,
+http://www.pdhre.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,
 https://www.suarakita.org/,LGBT,LGBT,2014-04-15,citizenlab,
 https://www.arabchurch.com/,REL,Religion,2014-04-15,citizenlab,
 http://papuapost.com/,NEWS,News Media,2017-04-24,sinarproject,Papua conflict 


### PR DESCRIPTION
Focus changeover. No known new or alternative site of People's Movement for Human Rights Learning.
Last known active: https://web.archive.org/web/20220913031524/http://pdhre.org/