### PR TITLE
Removed http://www.ruf-ch.org/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -771,7 +771,6 @@ http://www.rollingstone.com/,CULTR,Culture,2014-04-15,citizenlab,Updated by OONI
 http://www.rollitup.org/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.royalvegas.com/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.rt.com/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.ruf-ch.org/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.runescape.com/,GAME,Gaming,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.rxmarijuana.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.samesexmarriage.ca/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Domain expired. No known new or alternative website.
https://web.archive.org/web/20230607065819/http://www.ruf-ch.org/