### PR TITLE
Removed http://www.hrusa.org/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -527,7 +527,6 @@ https://www.hotbot.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OON
 https://www.hotspotshield.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.hrc.org/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.hrea.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.hrusa.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.hrw.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.http-tunnel.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.huffpost.com/,NEWS,News Media,2014-04-15,citizenlab,Updated on 2022-02-25


### PR DESCRIPTION
Dead link. No known new or alternative site. Last known active: https://web.archive.org/web/20210823060903/http://www.hrusa.org/