### PR TITLE
Follow-up PR

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -778,7 +778,6 @@ http://www.sealswcc.com/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI o
 https://www.search.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.searchindia.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.securenym.net/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.securitytracker.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.securityfocus.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.secfirst.org/,HUMR,Human Rights Issues,2017-11-09,securityfirst,
 https://www.sendspace.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14

--- a/lists/global.csv
+++ b/lists/global.csv
@@ -778,7 +778,6 @@ http://www.sealswcc.com/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI o
 https://www.search.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.searchindia.com/,SRCH,Search Engines,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.securenym.net/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.securityfocus.com/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.secfirst.org/,HUMR,Human Rights Issues,2017-11-09,securityfirst,
 https://www.sendspace.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.sendthisfile.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
I reverted https://github.com/citizenlab/test-lists/pull/1590/commits/d906e188eef4da87d864c8caf2e1a0e5e206aebf because it undo both #1589 by re-adding http://www.securitytracker.com/ and #1590 by re-adding http://www.securityfocus.com/