### PR TITLE
fix(www.jsf.mil): http => https

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -589,7 +589,7 @@ http://www.jhr.ca/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OON
 https://www.jihadwatch.org/,POLR,Political Criticism,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.jmarshall.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.jmarshall.com/tools/cgiproxy/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.jsf.mil/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+https://www.jsf.mil/,GOVT,Government,2014-04-15,citizenlab,Updated by OONI on 2024-01-25
 http://www.judaism.com/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.judaismconversion.org/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.kali.org/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated on 2022-03-18


### PR DESCRIPTION
As noted by https://github.com/ooni/probe/issues/2329, we cannot access http://www.jsf.mil/ but we can access https://www.jsf.mil/.

See also https://explorer.ooni.org/chart/mat?since=2023-12-26&until=2024-01-26&time_grain=day&axis_x=measurement_start_day&test_name=web_connectivity&domain=www.jsf.mil

Closes https://github.com/ooni/probe/issues/2329.