### PR TITLE
[th] - Remove JD, Robinson, BEC-Tero Radio

### DIFF
--- a/lists/th.csv
+++ b/lists/th.csv
@@ -264,17 +264,14 @@ https://www.bigc.co.th/,COMM,E-commerce,2020-05-31,netalitica,Hypermart
 https://www.bnn.in.th/,COMM,E-commerce,2020-05-31,netalitica,"Computer, electronics, and accessories"
 https://www.central.co.th/,COMM,E-commerce,2020-05-31,netalitica,Online department store
 https://www.homepro.co.th/,COMM,E-commerce,2020-05-31,netalitica,Hardware store
-https://www.jd.co.th/,COMM,E-commerce,2020-05-31,netalitica,E-commerce platform
 https://www.jib.co.th/,COMM,E-commerce,2020-05-31,netalitica,"Computer, electronics, and accessories"
 https://www.lazada.co.th/,COMM,E-commerce,2020-05-31,netalitica,E-commerce platform
 https://www.lnwshop.com/,COMM,E-commerce,2020-05-31,netalitica,E-commerce platform
 https://www.powerbuy.co.th/,COMM,E-commerce,2020-05-31,netalitica,"Electronics, home appliances"
-https://www.robinson.co.th/,COMM,E-commerce,2020-05-31,netalitica,Online department store
 https://shopee.co.th/,COMM,E-commerce,2020-05-31,netalitica,E-commerce platform
 https://www.tops.co.th/th/,COMM,E-commerce,2020-05-31,netalitica,Supermarket
 https://www.watsons.co.th/,COMM,E-commerce,2020-05-31,netalitica,Personal care and cosmetics
 https://www.037hdmovie.com/,CULTR,Culture,2020-05-31,netalitica,Watch movie online [th]
-http://www.becteroradio.com/,CULTR,Culture,2020-05-31,netalitica,Online radio [th]
 http://jazzmoment.com/blog/,CULTR,Culture,2020-05-31,netalitica,"Music, movie, and cultural review [th]"
 https://www.justeconomylabor.org/,ECON,Economics,2020-05-31,netalitica,Just Economy and Labor Institute [en]
 https://www.playpark.com/,GAME,Gaming,2020-05-31,netalitica,Computer games


### PR DESCRIPTION
- Remove JD https://www.jd.co.th/ - no longer in operation, URL inaccessible, no history of blocking
  - "JD Central to end Thai operations on March 3" (31 Jan 2023) https://www.bangkokpost.com/business/general/2494934/jd-central-to-end-thai-operations-on-march-3 
- Remove Robinson https://www.robinson.co.th/ - no longer in operation in its previous form (now a sub-brand within Central department store website), URL inaccessible, no history of blocking
  - "CRC Announces Strategic Move, Combining the Strengths of Central and Robinson to Benefit Thai Customers" (17 Sep 2020) https://www.centralgroup.com/en/updates/corporate-news/460/crc-announces-strategic-move-combining-the-strengths-of-central-and-robinson-to-benefit-thai-customers 
- Remove BEC Tero Radio http://www.becteroradio.com/ - no longer in operation in its previous form (now Tero Radio, after restructure of shareholders), URL inaccessible, no history of blocking
  - BEC group disposed the investment in BEC-Tero in December 2020 (8 Dec 2020) http://market.sec.or.th/public/idisc/Download?FILEID=dat/news/202012/20137458.pdf