### PR TITLE
Removed http://www.netzoola.com/

### DIFF
--- a/lists/ae.csv
+++ b/lists/ae.csv
@@ -83,6 +83,7 @@ http://www.thekoran.com/,REL,Religion,2014-04-15,citizenlab,
 http://www.thequran.com/,REL,Religion,2014-04-15,citizenlab,
 http://www.stupidcensorship.com/,ANON,Anonymization and circumvention tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.islamic-relief.com/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+http://www.callserve.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.middleeasteye.net/,NEWS,News Media,2016-07-13,citizenlab,
 https://www.alaraby.co.uk/,NEWS,News Media,2016-10-23,OONI,
 http://textsecure-service-ca.whispersystems.org/,COMT,Communication Tools,2017-01-23,citizenlab,Used by Signal desktop

--- a/lists/global.csv
+++ b/lists/global.csv
@@ -334,7 +334,7 @@ https://www.btselem.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated 
 http://www.buddhanet.net/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.budweiser.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Reversed PR #1114 by OONI on 2022-09-29
 https://www.buydutchseeds.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.callserve.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
+https://www.vyke.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated on 2024-07-08
 https://www.cannaweed.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by OONI on 2022-09-14
 https://www.caritas.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2022-09-14
 http://www.casinotropez.com/,GMB,Gambling,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -656,7 +656,6 @@ http://www.neonjoint.com/,ALDR,Alcohol & Drugs,2014-04-15,citizenlab,Updated by 
 http://www.netaddress.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.netaddress.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.netflix.com/,MMED,Media sharing,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.netzoola.com/,COMT,Communication Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.newnownext.com/franchise/the-backlot/,LGBT,LGBT,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://www.ning.com/,GRP,Social Networking,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.nmrc.org/,HACK,Hacking Tools,2014-04-15,citizenlab,Updated by OONI on 2017-02-14


### PR DESCRIPTION
Dead link. No known new or alternative website of NetZooLa. Last known active: https://web.archive.org/web/20200220234831/https://www.netzoola.com/

Callserve had migrated to Vyke: https://web.archive.org/web/20110613125549/http://www.callserve.com/Homepage.asp