### PR TITLE
Adds 3 pornographic websites to the fr list

### DIFF
--- a/lists/fr.csv
+++ b/lists/fr.csv
@@ -89,3 +89,6 @@ https://www.sci-hub.wf/,FILE,File-sharing,2024-10-06,Community Member,Sci-hub do
 https://yggtorrent.lol/,FILE,File-sharing,2024-10-06,Community Member,torrent website
 https://www.ygg.re/,FILE,File-sharing,2024-10-06,Community Member,torrent website
 https://yggtorrent.to/,FILE,File-sharing,2024-10-06,Community Member,torrent website
+https://tukif.com/,PORN,Pornography,2024-10-19,Community Member,Blocked website according to a recent court decision
+https://www.mrsexe.com/,PORN,Pornography,2024-10-19,Community Member,Blocked website according to a recent court decision
+https://www.iciporno.com/,PORN,Pornography,2024-10-19,Community Member,Blocked website according to a recent court decision


### PR DESCRIPTION
Hi,

A recent decision by the court of appeal in France has asked ISPs to block 4 pornographic websites : TuKif, xHamster, MrSexe, and IciPorno, see https://www.euronews.com/next/2024/10/17/foreign-porn-websites-blocked-in-france-for-lack-of-age-control-checks

Here is a PR to adds 3 of them, xhamster is already in the Global list.

Let me know if you have any questions