### PR TITLE
Removed http://www.islamdoor.com/

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -571,7 +571,6 @@ https://www.ipvanish.com/,ANON,Anonymization and circumvention tools,2014-04-15,
 http://www.irna.ir/,NEWS,News Media,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.isiswomen.org/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.iskcon.com/,HUMR,Human Rights Issues,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
-http://www.islamdoor.com/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.islameyat.com/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 https://islamic-relief.org/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
 http://www.islamicity.com/,REL,Religion,2014-04-15,citizenlab,Updated by OONI on 2017-02-14
@@ -1058,7 +1057,7 @@ http://www.ibe.unesco.org/,IGO,Intergovernmental Organizations,2019-09-25,OONI,
 https://www.iaea.org/,ENV,Environment,2019-09-25,OONI,
 https://www.aljazeera.com/,NEWS,News Media,2019-09-19,OONI,
 http://www.ecequality.org/,LGBT,LGBT,2019-11-18,OutRight International,
-https://www.pridemedia.com/,LGBT,LGBT,2019-11-18,OutRight International,
+https://equalpride.com/,LGBT,LGBT,2019-11-18,OutRight International,
 https://pridesource.com/article/top-10-international-lgbt-stories-of-2018/,LGBT,LGBT,2019-11-18,OutRight International,
 https://www.familyequality.org/events/international-family-equality-day/,LGBT,LGBT,2019-11-18,OutRight International,
 https://internationalfamilyequalityday.org/,LGBT,LGBT,2019-11-18,OutRight International,


### PR DESCRIPTION
Dead link. Last known active: https://web.archive.org/web/20210802205856/https://www.islamdoor.com/

Also, replaced `https://www.pridemedia.com/` with `https://equalpride.com/`