### PR TITLE
Adding more domains supposed to be blocked in France

### DIFF
--- a/lists/fr.csv
+++ b/lists/fr.csv
@@ -77,6 +77,12 @@ https://win-ma-chance.casino/,GMB,Gambling,2024-10-06,Community Member,illegal g
 https://www.betflip.io/,GMB,Gambling,2024-10-06,Community Member,illegal gambling website
 https://yonibet.com/,GMB,Gambling,2024-10-06,Community Member,illegal gambling website
 https://yonibet3.io/,GMB,Gambling,2024-10-06,Community Member,illegal gambling website
+https://mrsloty.com/,GMB,Gambling,2025-01-16,Community Member,illegal gambling website
+https://rivieracasino.fr/,GMB,Gambling,2025-01-16,Community Member,illegal gambling website
+https://vave.com/,GMB,Gambling,2025-01-16,Community Member,illegal gambling website
+https://leoncasino.fr/,GMB,Gambling,2025-01-16,Community Member,illegal gambling website
+https://www.luckyblock.top/,GMB,Gambling,2025-01-16,Community Member,illegal gambling website
+https://cuscocasino.com/,GMB,Gambling,2025-01-16,Community Member,illegal gambling website
 https://rg.ru/,NEWS,News Media,2024-10-06,Community Member,EU sanctions
 https://sarabic.ae/,NEWS,News Media,2024-10-06,Community Member,EU sanctions
 https://lat.rt.rs/,NEWS,News Media,2024-10-06,Community Member,EU sanctions
@@ -84,6 +90,7 @@ https://tsargrad.tv/,NEWS,News Media,2024-10-06,Community Member,EU sanctions
 https://ivran.ru/,NEWS,News Media,2024-10-06,Community Member,EU sanctions
 https://katehon.com/,NEWS,News Media,2024-10-06,Community Member,EU sanctions
 https://iz.ru/,NEWS,News Media,2024-10-06,Community Member,EU sanctions
+https://smotrim.ru/,NEWS,News Media,2024-10-06,Community Member,EU sanctions
 https://sci-hub.ru/,FILE,File-sharing,2024-10-06,Community Member,Sci-hub domain
 https://www.sci-hub.wf/,FILE,File-sharing,2024-10-06,Community Member,Sci-hub domain
 https://yggtorrent.lol/,FILE,File-sharing,2024-10-06,Community Member,torrent website
@@ -92,3 +99,5 @@ https://yggtorrent.to/,FILE,File-sharing,2024-10-06,Community Member,torrent web
 https://tukif.com/,PORN,Pornography,2024-10-19,Community Member,Blocked website according to a recent court decision
 https://www.mrsexe.com/,PORN,Pornography,2024-10-19,Community Member,Blocked website according to a recent court decision
 https://www.iciporno.com/,PORN,Pornography,2024-10-19,Community Member,Blocked website according to a recent court decision
+https://fr.xhamster.com/,PORN,Pornography,2025-01-16,Community Member,Blocked website according to a recent court decision
+https://makrea.com/,COMM,E-commerce,2025-01-16,Community Member,Website blocked for fraud


### PR DESCRIPTION
Hi everyone,

This PR adds more websites blocked in France:
* For unlawful online gambling (see details [here](https://censxres.fr/administrative/jeux-en-ligne/))
* Pornographic website
* Website blocked for frauds, see here https://signal.conso.gouv.fr/fr/actualites/deux-sites-frauduleux-bloques
* Smotrim is [a russian TV platform](https://en.wikipedia.org/wiki/Smotrim) that now host Russia 1 (which is supposed to be blocked in Europe due to the Council of the European Union