### PR TITLE
Remove cf ipfs gateways

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1502,8 +1502,6 @@ https://meet.jit.si/,COMT,Communication Tools,2023-05-16,test-lists.ooni.org con
 https://www.njal.la/,ANON,Anonymization and circumvention tools,2023-05-26,gus,
 https://ipfs.io/,COMT,Communication Tools,2023-06-04,willscott,IPFS Gateway
 https://dweb.link/,COMT,Communication Tools,2023-06-26,lidel,IPFS Gateway with Origin per CID (same s ipfs.io)
-https://cloudflare-ipfs.com/,COMT,Communication Tools,2023-06-04,willscott,IPFS Gateway
-https://cf-ipfs.com/,COMT,Communication Tools,2023-06-26,lidel,IPFS Gateway with ORigin per CID (same as cloudflare-ipfs.com)
 https://cid.contact/,COMT,Communication Tools,2023-06-04,willscott,
 https://abortionpillinfo.org/,XED,Sex Education,2023-06-13,gus,
 https://womenhelp.org/,XED,Sex Education,2023-06-13,gus,


### PR DESCRIPTION
Cloudflare IPFS gateways are discontinued: https://blog.cloudflare.com/cloudflares-public-ipfs-gateways-and-supporting-interplanetary-shipyard/