### PR TITLE
Added ENV sites to Global test list

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1663,3 +1663,6 @@ https://cpj.org/,NEWS,News Media,2025-04-25,test-lists.ooni.org contribution,
 https://defenddefenders.org/,HUMR,Human Rights Issues,2025-04-25,test-lists.ooni.org contribution,
 https://www.buzzfeed.com/,NEWS,News Media,2025-05-09,test-lists.ooni.org contribution,
 https://www.happn.com/,DATE,Online Dating,2025-05-09,test-lists.ooni.org contribution,
+https://www.resourcematters.org/,ENV,Environment,2025-05-24,OONI,Reportedly blocked in the DRC but worth testing globally
+https://redapes.org/,ENV,Environment,2025-05-24,OONI,Reportedly blocked in the DRC but worth testing globally
+https://globalconservation.org/,ENV,Environment,2025-05-24,OONI,Reportedly blocked in the DRC but worth testing globally


### PR DESCRIPTION
This PR adds 3 environmental sites to the Global test list which are reportedly blocked in the DRC, but which are worth testing and monitoring globally. 