### PR TITLE
Create a directory for social media URLs

### DIFF
--- a/social-media/ae.csv
+++ b/social-media/ae.csv
@@ -1,0 +1,7 @@
+url,category_code,category_description,date_added,source,notes
+https://www.facebook.com/GayStarNews/,LGBT,LGBT,2017-10-20,citizenlab,
+https://www.facebook.com/EmiratiAffairs/,POLR,Political Criticism,2017-10-20,citizenlab,
+https://www.facebook.com/Moh.alrashed/,POLR,Political Criticism,2017-10-20,citizenlab,
+https://www.facebook.com/alqaradawy/,POLR,Political Criticism,2017-10-20,citizenlab,
+https://www.facebook.com/bostan.ikhwan/,POLR,Political Criticism,2017-10-20,citizenlab,
+https://twitter.com/arabatheisttv/,REL,Religion,2017-10-20,citizenlab,Arab atheists


### PR DESCRIPTION
This PR adds a new directory to store the URLs of specific social media pages and profiles. 

Currently, numerous URLs pertaining to specific profiles on Facebook, Twitter, YouTube, etc, are stored as part of the test lists, creating duplicates with the Global list. 

Since all social media are already tested globally, we suggest moving them to separate files, so that researchers could use them if needed. 

As part of the PR, I created an example csv for the UAE test list. I suggest keeping the same format of the tables and the same categorization to store social media URLs to make the lists more usable for the researchers in the future. 