### PR TITLE
Added latest website of Justice For Sisters

### DIFF
--- a/lists/my.csv
+++ b/lists/my.csv
@@ -249,7 +249,8 @@ https://www.themalaysianinsight.com/,NEWS,News Media,2017-10-11,sinarproject,
 https://amanah.org.my/,POLR,Political Criticism,2017-10-11,sinarproject,political party
 https://bersatu.org/,POLR,Political Criticism,2017-10-11,sinarproject,political party
 https://www.asiaone.com/,NEWS,News Media,2017-10-24,sinarproject,
-https://justiceforsisters.wordpress.com/,LGBT,LGBT,2017-10-25,sinarproject,
+https://justiceforsisters.wordpress.com/,LGBT,LGBT,2017-10-25,sinarproject,Old website of Justice For Sisters last updated in May 2025. Kept for monitoring purposes
+https://justiceforsisters.org/,LGBT,LGBT,2026-01-12,sinarproject,New website of Justice For Sisters
 http://www.ocdn.com.my/,NEWS,News Media,2017-10-27,sinarproject,
 https://news.seehua.com/,NEWS,News Media,2017-10-27,sinarproject,
 https://www.enanyang.my/,NEWS,News Media,2017-10-27,sinarproject,


### PR DESCRIPTION
Added latest website of Justice For Sisters (https://justiceforsisters.org/en/). Old website (https://justiceforsisters.wordpress.com/) is kept for monitoring