### PR TITLE
Added URLs to PH test list

### DIFF
--- a/lists/ph.csv
+++ b/lists/ph.csv
@@ -91,7 +91,6 @@ http://deviantclip.com/,PORN,Pornography,2018-12-27,engagemedia,
 http://jizzhut.com/,PORN,Pornography,2018-12-27,engagemedia,
 http://eporner.com/,PORN,Pornography,2018-12-27,engagemedia,
 https://xxx.com/,PORN,Pornography,2018-12-27,engagemedia,
-http://rude.com/,PORN,Pornography,2018-12-27,engagemedia,
 https://efukt.com/,PORN,Pornography,2018-12-27,engagemedia,
 http://www.katestube.com/,PORN,Pornography,2018-12-27,engagemedia,
 http://www.porntube.com/,PORN,Pornography,2018-12-27,engagemedia,
@@ -261,3 +260,6 @@ https://kilusangmayouno.com/,HUMR,Human Rights Issues,2024-12-31,test-lists.ooni
 https://lakascmd.com/,POLR,Political Criticism,2025-04-25,community member,Lakas-Christian Muslim Democrats - The Dominant Majority Party for the Upcoming 2025 National and Local Elections
 https://nup.org.ph/,POLR,Political Criticism,2025-04-25,community member,National Unity Party - One of the Major National Parties for the Upcoming 2025 National and Local Elections
 https://pdplaban.org.ph/,POLR,Political Criticism,2025-04-25,community member,Partido Demokratiko Pilipino-Lakas ng Bayan - One of the Major National Parties for the Upcoming 2025 National and Local Elections
+https://blockchain.open.gov.ph/,GOVT,Government,2026-01-17,community member,"A transparent, verifiable portal for the Philippine National Budget"
+https://x.ai/,CULTR,Culture,2026-01-17,community member,Blocked due to its misuse in generating non-consensual sexually explicit content and deepfakes
+https://grok.com/,CULTR,Culture,2026-01-17,community member,Blocked due to its misuse in generating non-consensual sexually explicit content and deepfakes


### PR DESCRIPTION
The URLs were added (and removed) due to the following:
- The Philippines put its entire [national budget on blockchain](https://dict.gov.ph/news-and-updates/25385)
- Grok AI is now [banned in the Philippines](https://cicc.gov.ph/news/grok-ai-no-more-access-starting-today/)
- `http://rude.com/` is for sale