### PR TITLE
Add cloudflare domain being blocked by La Liga in Spain

### DIFF
--- a/lists/es.csv
+++ b/lists/es.csv
@@ -65,3 +65,5 @@ https://www.sectorgaming.tv/,NEWS,News Media,2025-12-03,test-lists.ooni.org cont
 https://www.goalsport.info/,MMED,Media sharing,2025-11-28,test-lists.ooni.org contribution,football streaming site
 https://rojadirectahd.my/,MMED,Media sharing,2025-11-28,test-lists.ooni.org contribution,football streaming site
 https://rojadirectatv.global/,MMED,Media sharing,2025-11-28,test-lists.ooni.org contribution,football streaming site
+https://cdnjs.cloudflare.com/,MMED,Media sharing,2026-02-23,User contribution,Domain being blocked as a result of the judicial power granted to La Liga to prevent the transmission of illegal content.
+https://cloudflarestream.com/,MMED,Media sharing,2026-02-23,User contribution,Domain being blocked as a result of the judicial power granted to La Liga to prevent the transmission of illegal content.

--- a/lists/es.csv
+++ b/lists/es.csv
@@ -65,5 +65,4 @@ https://www.sectorgaming.tv/,NEWS,News Media,2025-12-03,test-lists.ooni.org cont
 https://www.goalsport.info/,MMED,Media sharing,2025-11-28,test-lists.ooni.org contribution,football streaming site
 https://rojadirectahd.my/,MMED,Media sharing,2025-11-28,test-lists.ooni.org contribution,football streaming site
 https://rojadirectatv.global/,MMED,Media sharing,2025-11-28,test-lists.ooni.org contribution,football streaming site
-https://cdnjs.cloudflare.com/,MMED,Media sharing,2026-02-23,User contribution,Domain being blocked as a result of the judicial power granted to La Liga to prevent the transmission of illegal content.
 https://cloudflarestream.com/,MMED,Media sharing,2026-02-23,User contribution,Domain being blocked as a result of the judicial power granted to La Liga to prevent the transmission of illegal content.


### PR DESCRIPTION
These blocks are supported by judicial authority granted by the Spanish government to La Liga (a private company that produces pay-per-view football content) to prevent users from accessing pirated streams. Please see links to related legal documents below.

These disruptions have been widely reported by users in Spain across various internet service providers. Because these blocks are implemented across entire Cloudflare IP ranges or domains, they inadvertently disrupt a significant number of other legitimate internet services that rely on Cloudflare’s infrastructure.

Consequently, multiple legitimate web services cease to function properly whenever a football match is broadcasted, causing unjustified disruption to the companies that rely on them.

# My observations and reasons
I run a professional networking site with around 30k spain-based users. We use cloudflare extensively throughout most of our services, as do thousands of other internet-based companies. As a result of this blocks, some of our users cannot access our service whenever there's a live football match on TV broadcasted by La Liga.

We observed this issue by testing it ourselves using proper procedures involving multiple ISP entry points and scenarios,  but we also regularly receive reports from our users that claim our responsibility for the service interruptions.

# Why we think these two domains should be added to OONI list
The problems manifest mainly in the following ways:

- When a site relies on any javascript being hosted at Cloudflare, and the `cdnjs.cloudflare.com` domain is being blocked, the site or the functionality involving that javascript ceases to work. When the javascript is needed for the normal operation of the site, the entire site may appear broken or not load at all.

> `cdnjs.cloudflare.com` is not including on this PR as it's already being monitored via the global CSV.

- When a site uses the [Cloudflare stream](https://www.cloudflare.com/developer-platform/products/cloudflare-stream/) service to host videos, those videos are served via subdomains under the `cloudflarestream.com` domain. When the blocks are in place, videos on the site won't load.

Sometimes the blocks are performed in a way that the TCP connection is severed abruptly, causing the browser to keep on waiting for a response, and thus giving the user the impression of a "loading" page that never ends.

I think OONI should include this domain in order to monitor this blockages. This would provide reporters and influencers a reliable source of truth to prove the blockages from a neutral point of view, based on the reports sent by OONI probes running in Spain.

# Sources of information
## On the news
- [Vercel: Update on Spain and LALIGA blocks of the internet](https://vercel.com/blog/update-on-spain-and-laliga-blocks-of-the-internet)
- [AP News: Spanish soccer league battles Cloudflare over piracy, says US company ignores illegal content](https://apnews.com/article/laliga-cloudflare-piracy-spanish-league-ae520f11b6926476e79fbb9954463f05)
- [Broadband TV news: Spanish court orders NordVPN and ProtonVPN to block LaLiga pirate streams](https://www.broadbandtvnews.com/2026/02/17/spanish-court-orders-nordvpn-and-protonvpn-to-block-laliga-pirate-streams/)
- [Cinco días: Movistar y LaLiga logran que se consolide el bloqueo de webs piratas en tres horas](https://cincodias.elpais.com/cincodias/2022/08/03/companias/1659550036_604654.html)
- [Techradar: On additional VPN blocks by LALIGA](https://www.techradar.com/vpn/vpn-privacy-security/la-liga-wins-court-order-requiring-nordvpn-and-proton-vpn-to-block-illegal-football-streams-in-spain-but-vpn-firms-say-they-have-not-been-notified)
- [Official statement by LaLiga](https://www.laliga.com/en-GB/news/official-statement-in-relation-to-the-blocking-of-ips-during-the-recent-ea-sports-laliga-matchdays-linked-to-illegal-cloudflare-practices)
- [LaLigaGate (spanish)](https://laligagate.com/)

## Legal information
- [Oficial legal resolution document, sentence 310/2024, Barcelona, 2024/12/19](https://www.poderjudicial.es/search/AN/openDocument/766326fb999ba14aa0a8778d75e36f0d/20250331)
- [AEDD: The Commercial Court of Barcelona fully upholds LaLiga's claim for the illicit distribution of content (spanish))](https://aedd.org/noticias-derecho-deportivo/novedades-jurisprudenciales/item/3382-el-juzgado-de-lo-mercantil-de-barcelona-estima-integramente-la-demanda-de-laliga-por-la-distribucion-ilicita-de-contenidos)