### PR TITLE
Add Proton VPN API domain to Global test list

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1722,3 +1722,4 @@ https://genderdysphoria.fyi/,LGBT,LGBT,2025-11-11,test-lists.ooni.org contributi
 https://www.access-unlocked.org/,ANON,Anonymization and circumvention tools,2025-12-08,OONI,New DW website for censorship circumvention tools
 https://chat.openai.com/,CULTR,Culture,2025-12-13,test-lists.ooni.org contribution,AI-powered content generation platform; may be blocked due to restrictions on AI or online content in some countries. Collateral damage of Cloudflare shutdowns in Spain due to LaLiga.
 https://unredacted.org/,ANON,Anonymization and circumvention tools,2026-01-02,OONI,privacy and circumvention related project
+https://vpn-api.proton.me/,ANON,Anonymization and circumvention tools,2026-04-21,OONI,


### PR DESCRIPTION
This PR adds the domain used by Proton VPN clients to reach the Proton API to the Global test list. 