### PR TITLE
(cn/ru) Add Substack CDN and tracking domain URLs

### DIFF
--- a/lists/cn.csv
+++ b/lists/cn.csv
@@ -589,3 +589,8 @@ https://ici.radio-canada.ca/,NEWS,News Media,2025-03-06,OONI,
 https://www3.nhk.or.jp/,NEWS,News Media,2025-03-06,OONI,
 https://www.zhihu.com/,CULTR,Culture,2025-12-27,test-lists.ooni.org contribution,Q&A website
 https://www.gov.cn/,GOVT,Government,2025-12-27,test-lists.ooni.org contribution,chinese government website gate
+https://substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community with sometimes dissenting opinions
+https://open.substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 302)
+https://email.mg-d1.substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 404)
+https://substackcdn.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 403)
+https://eotrx.substackcdn.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community

--- a/lists/cn.csv
+++ b/lists/cn.csv
@@ -589,7 +589,6 @@ https://ici.radio-canada.ca/,NEWS,News Media,2025-03-06,OONI,
 https://www3.nhk.or.jp/,NEWS,News Media,2025-03-06,OONI,
 https://www.zhihu.com/,CULTR,Culture,2025-12-27,test-lists.ooni.org contribution,Q&A website
 https://www.gov.cn/,GOVT,Government,2025-12-27,test-lists.ooni.org contribution,chinese government website gate
-https://substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community with sometimes dissenting opinions
 https://open.substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 302)
 https://email.mg-d1.substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 404)
 https://substackcdn.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 403)

--- a/lists/ru.csv
+++ b/lists/ru.csv
@@ -1083,3 +1083,8 @@ https://images.apple.com/,GRP,Social Networking,2025-11-03,test-lists.ooni.org c
 https://scripts.google.com/,SRCH,Search Engines,2026-03-16,test-lists.ooni.org contribution,
 https://www.shantdigitaltv.com/,NEWS,News Media,2026-04-28,OONI,Armenian TV channel reportedly blocked in Russia
 https://golive.shantdigitaltv.com/,NEWS,News Media,2026-04-28,OONI,Armenian TV channel reportedly blocked in Russia
+https://substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community with sometimes dissenting opinions
+https://open.substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 302)
+https://email.mg-d1.substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 404)
+https://substackcdn.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 403)
+https://eotrx.substackcdn.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community

--- a/lists/ru.csv
+++ b/lists/ru.csv
@@ -1083,7 +1083,6 @@ https://images.apple.com/,GRP,Social Networking,2025-11-03,test-lists.ooni.org c
 https://scripts.google.com/,SRCH,Search Engines,2026-03-16,test-lists.ooni.org contribution,
 https://www.shantdigitaltv.com/,NEWS,News Media,2026-04-28,OONI,Armenian TV channel reportedly blocked in Russia
 https://golive.shantdigitaltv.com/,NEWS,News Media,2026-04-28,OONI,Armenian TV channel reportedly blocked in Russia
-https://substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community with sometimes dissenting opinions
 https://open.substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 302)
 https://email.mg-d1.substack.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 404)
 https://substackcdn.com/,HOST,Hosting and Blogging Platforms,2026-05-28,451 Labs,Email newsletter and blogging community (expect 403)


### PR DESCRIPTION
Test for the availability of Substack domains, used for email newsletter content delivery and open tracking.

👉 Several top-level resources return redirection (3xx) or error (4xx) status codes.