### PR TITLE
Added domains blocked by the CUII to de.csv

### DIFF
--- a/lists/de.csv
+++ b/lists/de.csv
@@ -61,3 +61,129 @@ https://kurdistan-report.de/,POLR,Political Criticism,2025-11-10,test-lists.ooni
 https://rote-hilfe.de/,POLR,Political Criticism,2025-11-10,test-lists.ooni.org contribution,"left-wing legal and prisoner support group, government discussed ban in 2018"
 https://www.kon-med.com/,POLR,Political Criticism,2025-11-10,test-lists.ooni.org contribution,umbrella organization of kurdish people in germany
 https://www.jugendinfo.blog/,POLR,Political Criticism,2025-11-10,test-lists.ooni.org contribution,youth-focused left-wing blog about international politics
+https://annas-archive.gd/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://annas-archive.pk/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://buffsports.io/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://buffstreams.sx/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://canna-power.to/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://cine.to/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://filmpalast.one/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://filmpalast.pro/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://fitgirl-repacks.site/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://getrockmusic.net/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://harleyquinnwidget.net/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://hdfilme.app/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://hdfilme.bid/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://hdfilme.blog/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://hdfilme.legal/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://hdfilme.my/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://hdfilme.party/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://hdfilme.press/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://hdfilme.uno/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://hesgoalguide.com/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://ibooks.bz/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://ibooks.to/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://israbox-music.com/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://israbox.com/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://isrbx.com/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://isrbx.me/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://isrbx.net/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://jokerlivestream.net/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://jokerlivestream.org/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://jokertvguide.sx/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://kinoger.co/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://kinoger.to/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://kinos.to/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://kinoz.to/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://libgen.bz/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://libgen.gl/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://libgen.la/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://libgen.vg/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://livetv.sx/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://livetv882.me/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.biz/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.boo/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.cat/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.club/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.dad/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.do/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.fans/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.fi/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.haus/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.how/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.ink/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.ist/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.jetzt/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.kiwi/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.la/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.live/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.lol/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.ms/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.one/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.soy/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.spa/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.tw/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino.win/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.bz/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.club/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.com/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.cx/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.fit/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.net/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.to/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.tv/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.vip/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.watch/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino1.ws/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino2.biz/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino2.net/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino2.org/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino2.to/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino2.tv/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino3.com/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino3.org/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino3.to/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://megakino3.tv/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://newerastreams.com/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://nox.tv/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://nswgame.com/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://nswpedia.com/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://nxbrew.net/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://qatarstreams.me/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://romslab.com/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://rpgonly.com/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://sci-hub.box/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://sci-hub.red/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://sci-hub.ru/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://sci-hub.st/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://sci-hub.su/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://serienfans.org/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://serienjunkies.biz/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://serienjunkies.eu/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://serienjunkies.info/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://serienjunkies.org/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://serienjunkies.us/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://serienstream.to/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://socceronline.me/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://soccerworldcup.me/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://sportplus.live/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://stikeout.im/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://streamcloud.my/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://streamcloud.plus/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://streamcloud.press/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://streamcloud.uno/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://switchroms.me/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://taodung.com/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://tazz.tv/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://tazztv.io/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://tennis.stream/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://vipbox.lc/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://vipboxtv.sk/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://vipleague.im/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://vipleague.io/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://vipleague.ws/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://vipleaguestreams.com/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://viprow.co/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://vipstand.cc/,MMED,Media sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://www.switchrom.net/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII
+https://ziperto.com/,FILE,File-sharing,2026-06-15,cuiiliste.de/lina.sh,Blocked by the CUII


### PR DESCRIPTION
These are domains that have been ordered to be blocked by the [CUII](https://cuii.info/), which all major German ISPs follow.
They have been compiled by us on [cuiiliste.de](https://cuiiliste.de/), here they have been de-duplicated, properly classified and removed if they appeared in other test lists.