### PR TITLE
Add domains blocked by German media authorities

### DIFF
--- a/lists/de.csv
+++ b/lists/de.csv
@@ -61,3 +61,10 @@ https://kurdistan-report.de/,POLR,Political Criticism,2025-11-10,test-lists.ooni
 https://rote-hilfe.de/,POLR,Political Criticism,2025-11-10,test-lists.ooni.org contribution,"left-wing legal and prisoner support group, government discussed ban in 2018"
 https://www.kon-med.com/,POLR,Political Criticism,2025-11-10,test-lists.ooni.org contribution,umbrella organization of kurdish people in germany
 https://www.jugendinfo.blog/,POLR,Political Criticism,2025-11-10,test-lists.ooni.org contribution,youth-focused left-wing blog about international politics
+https://de.mydirtyhobby.com/,PORN,Pornography,2026-06-15,lina.sh,Blocked by the Media Authority of Berlin-Brandenburg
+https://de.pornhub.com/,PORN,Pornography,2026-06-15,lina.sh,Multiple blocking orders by different media authorities
+https://de.pornhub.org/,PORN,Pornography,2026-06-15,lina.sh,Blocked by the Media Authority of North Rhine-Westphalia
+https://de.youporn.com/,PORN,Pornography,2026-06-15,lina.sh,Multiple blocking orders by different media authorities
+https://kalifat.com/,MILX,Terrorism and Militants,2026-06-15,lina.sh,Multiple blocking orders by different media authorities
+https://kalifat.io/,MILX,Terrorism and Militants,2026-06-15,lina.sh,Multiple blocking orders by different media authorities
+https://samidoun.net/,MILX,Terrorism and Militants,2026-06-15,lina.sh,Multiple blocking orders by different media authorities


### PR DESCRIPTION
Added domains that are currently under blocking orders by German state media authorities. These were acquired through multiple transparency and press requests, which can be found here: https://fragdenstaat.de/projekt/liste-von-gesperrten-domains-05-05-2026