### PR TITLE
Re-categorize Telegram URLs to social media

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1126,10 +1126,10 @@ https://tamtam.chat/,COMT,Communication Tools,2020-06-04,Chelchela,
 https://app.wire.com/,COMT,Communication Tools,2020-06-04,Chelchela,
 https://wire.com/,COMT,Communication Tools,2019-10-05,Mo,
 https://www.wechat.com/,COMT,Communication Tools,2019-10-05,Mo,
-https://telegram.org/,COMT,Communication Tools,2019-08-30,OONI partner,
-https://t.me/,COMT,Communication Tools,2019-08-30,OONI partner,
-https://tx.me/,COMT,Communication Tools,2020-06-04,Chelchela,
-https://telegram.me/,COMT,Communication Tools,2020-06-04,Chelchela,
+https://telegram.org/,GRP,Social Networking,2019-08-30,OONI partner,Recategorized by OONI in June 2026
+https://t.me/,GRP,Social Networking,2019-08-30,OONI partner,Recategorized by OONI in June 2026
+https://tx.me/,GRP,Social Networking,2020-06-04,Chelchela,Recategorized by OONI in June 2026
+https://telegram.me/,GRP,Social Networking,2020-06-04,Chelchela,Recategorized by OONI in June 2026
 https://telegra.ph/,HOST,Hosting and Blogging Platforms,2019-08-30,OONI partner,
 https://www.spotify.com/,CULTR,Culture,2020-06-04,Chelchela,
 http://tanzil.net/,REL,Religion,2017-03-09,CIPIT,Multilingual Quran -- Blocked in China


### PR DESCRIPTION
Telegram is frequently blocked around the world as part of broader "social media blocks", and it would therefore be useful to have it appear as part of the OONI Social Media Censorship Alert System. However, it currently does not appear in the alert system because it's categorized in the Global test list as `COMT` (which is technically correct).

As part of this PR, I have *re-categorized* Telegram URLs in the Global test list to `GRP` so that their testing can appear in the [OONI Social Media Censorship page](https://explorer.ooni.org/social-media), in the [OONI Social Media Censorship Alert System](https://explorer.test.ooni.org/alerts), in the OONI Explorer [Search](https://explorer.ooni.org/search) based on the "social networking" category, etc. 

Basically, the benefit of displaying censorship alerts for Telegram in our current alert system, and enabling our community to more easily discover measurements in "social media" categories, outweighs the cost (in my opinion) of being a little bit less accurate in the categorization. 