### PR TITLE
Add RT/Sputnik EU ban-evasion mirror domains

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1720,3 +1720,115 @@ https://unredacted.org/,ANON,Anonymization and circumvention tools,2026-01-02,OO
 https://vpn-api.proton.me/,ANON,Anonymization and circumvention tools,2026-04-21,OONI,
 https://www.inaturalist.org/,ENV,Environment,2026-04-28,OONI,Reportedly blocked in Russia but worth testing globally
 https://www.azattyqasia.org/,NEWS,News Media,2026-06-09,OONI,New Russian-language news platform focused on Central Asia which is reportedly blocked in Kazakhstan
+https://actualidad-rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
+https://af.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - خبرگزاری اسپوتنیک افغانستان - آخرین اخبا
+https://ar.rtarabic.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT Arabic
+https://arabic.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - سبوتنيك عربي – أخبار الدول العربية والعا
+https://armeniasputnik.am/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Արմենիա
+https://az.sputniknews.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Азербайджан - последние новости 
+https://bel.sputnik.by/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Навіны Беларусі і свету на беларускай мо
+https://big5.sputniknews.cn/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - 俄羅斯衛星通訊社 新聞：快訊，中國及國際新聞事件，頭條新聞及熱點問題
+https://br.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Brasil – Notícias Atuais do Mund
+https://de-rt.org/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://de-rtnews.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://dert.online/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://dert.site/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://dert.tech/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://deutsch.rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT DE
+https://dk.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik News - World News  Breaking News
+https://en.shop-rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - EN - SHOP-RT.COM
+https://en.sputniknews.africa/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Africa - World News  Breaking Ne
+https://es-rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
+https://es.rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT en Español - Noticias internacionales
+https://esp.rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT en Español - Noticias internacionales
+https://esrt.press/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
+https://esrt.tech/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
+https://fi.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik News - World News  Breaking News
+https://forum.rtarabic.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT Arabic
+https://fr.rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT en français — Actualités internationa
+https://fr.sputniknews.africa/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Afrique: actualités du jour  inf
+https://fr.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Afrique: actualités du jour  inf
+https://freeassange.rtde.life/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://freede.tech/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://freedert.online/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://hindi.sputniknews.in/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik भारत - भारत और दुनिया की गरमा गर
+https://ir.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - خبرگزاری اسپوتنیک ایران - آخرین اخبار جه
+https://jp.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - スプートニク日本ニュース｜経済、科学技術、ビジネス、政治ニュース
+https://lt.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Lietuva
+https://md.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Noutăți de ultimă oră din Moldova: cele 
+https://md.sputniknews.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Молдова - последние новости и гл
+https://mundo.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Mundo: noticias de última hora y
+https://no.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik News - World News  Breaking News
+https://noticias-rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
+https://notimundo.press/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
+https://oz.sputniknews-uz.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik O‘zbekiston
+https://pressefreiheit.rtde.life/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://radiosputnik.ria.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Радио Sputnik – новости онлайн  аналитик
+https://ro.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Știri de ultimă oră din România și din l
+https://rs.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Спутњик Вести: Најновије вести дана  нов
+https://rtd.rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - rt.doc Documentary Film Platform
+https://rtde.agency/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.expert/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.info/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.life/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.live/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.me/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.media/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.online/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.org/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.press/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.team/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.tech/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.website/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.world/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtde.xyz/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtdefree.info/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtdefree.me/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtdefree.online/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtdefree.tech/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtenfrance.tv/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en français — Actualités inte - shared Yandex Metrika 29473250
+https://rtespanol.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
+https://rtnewsde.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtnewsde.online/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtnewsde.pro/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtnewsde.site/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtnewsde.tech/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://rtnewsru.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT - Breaking News  Russia News  - shared Yandex Metrika 32550500
+https://rtrunews.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT - Breaking News  Russia News  - shared Yandex Metrika 32550500
+https://ru.sputnik.kg/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Новости Кыргызстана. Последние новости с
+https://ru.sputnik.kz/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Казахстан - последние новости и 
+https://runewsrt.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT - Breaking News  Russia News  - shared Yandex Metrika 32550500
+https://rurtnews.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT - Breaking News  Russia News  - shared Yandex Metrika 32550500
+https://russiatoday.ru/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT на русском: последние новости - shared Yandex Metrika 27102311
+https://school.rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT Школа
+https://se.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik News - World News  Breaking News
+https://shop-rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RU - SHOP-RT.COM
+https://sn-esp.site/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
+https://spanish.rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT en Español - Noticias internacionales
+https://sputnik-abkhazia.info/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Аҧсны
+https://sputnik-georgia.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik საქართველო: ახალი ამბები დღეს სპ
+https://sputnik-georgia.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Грузия - последние новости и гла
+https://sputnik-ossetia.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Хуссар Ирыстон
+https://sputnik-tj.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Tajikistan news today
+https://sputnik.by/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Беларусь - последние новости и г
+https://sputnik.kg/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Кыргызстан | Соңку кабарлар жана
+https://sputnik.kz/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Қазақстан
+https://sputnik.tj/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Tajikistan news today
+https://sputnikarabic.ae/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - سبوتنيك عربي – أخبار الدول العربية والعا
+https://sputnikmediabank.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Mediabank
+https://sputniknews-uz.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Ўзбекистон
+https://sputniknews.africa/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Afrique: actualités du jour  inf
+https://sputniknews.in/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik India – Latest News from India &
+https://sputniknews.jp/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - スプートニク日本ニュース｜経済、科学技術、ビジネス、政治ニュース
+https://sputniknews.kz/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Қазақстан
+https://sputniknews.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Ближнее зарубежье
+https://sputniknews.vn/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Tin tức – Sự kiện nóng  tin mớ
+https://sputniknewsbr.com.br/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Brasil – Notícias Atuais do Mund
+https://sputniknewslv.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders Sputnik Latvija - shared Yandex Metrika 35309785
+https://swentr.site/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT - Breaking News  Russia News  - shared Yandex Metrika 32550500
+https://test.rtde.tech/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
+https://tj.sputniknews.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Таджикистан - последние новости 
+https://tr.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Haberler - Dünya ve Türkiye Günd
+https://uk.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - United Kingdom (UK) - today's latest new
+https://uz.sputniknews.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Узбекистан - последние новости и
+https://vn.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Tin tức – Sự kiện nóng  tin mớ

--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1723,10 +1723,7 @@ https://www.azattyqasia.org/,NEWS,News Media,2026-06-09,OONI,New Russian-languag
 https://actualidad-rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
 https://af.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - خبرگزاری اسپوتنیک افغانستان - آخرین اخبا
 https://ar.rtarabic.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT Arabic
-https://arabic.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - سبوتنيك عربي – أخبار الدول العربية والعا
-https://armeniasputnik.am/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Արմենիա
 https://az.sputniknews.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Азербайджан - последние новости 
-https://bel.sputnik.by/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Навіны Беларусі і свету на беларускай мо
 https://big5.sputniknews.cn/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - 俄羅斯衛星通訊社 新聞：快訊，中國及國際新聞事件，頭條新聞及熱點問題
 https://br.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Brasil – Notícias Atuais do Mund
 https://de-rt.org/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
@@ -1746,22 +1743,18 @@ https://esrt.tech/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasio
 https://fi.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik News - World News  Breaking News
 https://forum.rtarabic.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT Arabic
 https://fr.rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT en français — Actualités internationa
-https://fr.sputniknews.africa/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Afrique: actualités du jour  inf
 https://fr.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Afrique: actualités du jour  inf
 https://freeassange.rtde.life/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
 https://freede.tech/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
 https://freedert.online/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
-https://hindi.sputniknews.in/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik भारत - भारत और दुनिया की गरमा गर
 https://ir.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - خبرگزاری اسپوتنیک ایران - آخرین اخبار جه
 https://jp.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - スプートニク日本ニュース｜経済、科学技術、ビジネス、政治ニュース
 https://lt.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Lietuva
-https://md.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Noutăți de ultimă oră din Moldova: cele 
 https://md.sputniknews.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Молдова - последние новости и гл
 https://mundo.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Mundo: noticias de última hora y
 https://no.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik News - World News  Breaking News
 https://noticias-rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
 https://notimundo.press/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
-https://oz.sputniknews-uz.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik O‘zbekiston
 https://pressefreiheit.rtde.life/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
 https://radiosputnik.ria.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Радио Sputnik – новости онлайн  аналитик
 https://ro.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Știri de ultimă oră din România și din l
@@ -1805,30 +1798,17 @@ https://se.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state m
 https://shop-rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RU - SHOP-RT.COM
 https://sn-esp.site/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT en Español - Noticias interna - shared Yandex Metrika 1641813
 https://spanish.rt.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - RT en Español - Noticias internacionales
-https://sputnik-abkhazia.info/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Аҧсны
-https://sputnik-georgia.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik საქართველო: ახალი ამბები დღეს სპ
 https://sputnik-georgia.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Грузия - последние новости и гла
-https://sputnik-ossetia.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Хуссар Ирыстон
 https://sputnik-tj.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Tajikistan news today
-https://sputnik.by/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Беларусь - последние новости и г
-https://sputnik.kg/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Кыргызстан | Соңку кабарлар жана
-https://sputnik.kz/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Қазақстан
-https://sputnik.tj/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Tajikistan news today
-https://sputnikarabic.ae/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - سبوتنيك عربي – أخبار الدول العربية والعا
 https://sputnikmediabank.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Mediabank
-https://sputniknews-uz.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Ўзбекистон
 https://sputniknews.africa/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Afrique: actualités du jour  inf
 https://sputniknews.in/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik India – Latest News from India &
-https://sputniknews.jp/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - スプートニク日本ニュース｜経済、科学技術、ビジネス、政治ニュース
 https://sputniknews.kz/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Қазақстан
 https://sputniknews.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Ближнее зарубежье
-https://sputniknews.vn/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Tin tức – Sự kiện nóng  tin mớ
 https://sputniknewsbr.com.br/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Brasil – Notícias Atuais do Mund
 https://sputniknewslv.com/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders Sputnik Latvija - shared Yandex Metrika 35309785
 https://swentr.site/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT - Breaking News  Russia News  - shared Yandex Metrika 32550500
 https://test.rtde.tech/,NEWS,News Media,2026-06-26,DebunkOrg,RT/Sputnik EU ban-evasion mirror - renders RT DE - shared Yandex Metrika 33614934
 https://tj.sputniknews.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Таджикистан - последние новости 
-https://tr.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Haberler - Dünya ve Türkiye Günd
 https://uk.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - United Kingdom (UK) - today's latest new
-https://uz.sputniknews.ru/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Узбекистан - последние новости и
 https://vn.sputniknews.com/,NEWS,News Media,2026-06-26,DebunkOrg,Russian state media (RT/Sputnik) - Sputnik Tin tức – Sự kiện nóng  tin mớ


### PR DESCRIPTION
This PR adds 112 RT and Sputnik domains — mostly EU ban-evasion mirror/clone sites that are currently unmonitored (zero OONI measurements). Each was content-verified (renders RT/Sputnik), and clones were confirmed via shared Yandex Metrika IDs and co-located hosting (89.191.237.0/24, 185.79.236.0/24). Goal: bring the evasion-mirror layer into OONI measurement so blocking gaps across EU countries become visible. Cross-referenced against the NLconnect EU media-sanctions reference list; ~12 are not on any public list.