### PR TITLE
Remove ntc.party entry from global.csv

### DIFF
--- a/lists/global.csv
+++ b/lists/global.csv
@@ -1277,7 +1277,6 @@ https://external.xx.fbcdn.net/robots.txt,GRP,Social Networking,2021-08-19,anonym
 https://fbcdn.net/robots.txt,GRP,Social Networking,2021-08-19,anonymous,Facebook CDN domains entries
 https://scontent.xx.fbcdn.net/robots.txt,GRP,Social Networking,2021-08-19,anonymous,Facebook CDN domains entries
 https://staticxx.facebook.com/robots.txt,GRP,Social Networking,2021-08-19,anonymous,Facebook CDN domains entries
-https://ntc.party/,GRP,Social Networking,2021-09-21,Chelchela,
 https://slack.com/,COMT,Communication Tools,2021-09-21,Chelchela,
 https://app.slack.com/robots.txt,COMT,Communication Tools,2021-09-21,Chelchela,
 https://a.slack-edge.com/f70ec/img/test_cdn_pixel.gif,COMT,Communication Tools,2021-09-21,Chelchela,


### PR DESCRIPTION
ntc.party only has a AAAA record, so it's not reliably being measured on networks that don't support IPv6.

We should consider moving it to only the russia test list